### PR TITLE
Write build script in Swift for easier composability of command-line arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ DerivedData
 .idea/
 .swiftpm/
 generated/
+*coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ script:
 matrix:
   include:
   - osx_image: xcode11.2
-    env: ACTION="swift-package";SDK="iphonesimulator";DESTINATION="platform=iOS Simulator,OS=13.2.2,name=iPad Pro (12.9-inch) (3rd generation)";BUILD="build test"
+    env: ACTION="swift-package";SDK="iphonesimulator";DESTINATION="platform=iOS Simulator,OS=13.2.2,name=iPad Pro (12.9-inch) (3rd generation)";SHOULD_TEST="true"
   - osx_image: xcode11.2
-    env: ACTION="swift-package";SDK="appletvsimulator13.2";DESTINATION="platform=tvOS Simulator,name=Apple TV";BUILD="build test"
+    env: ACTION="swift-package";SDK="appletvsimulator13.2";DESTINATION="platform=tvOS Simulator,name=Apple TV";SHOULD_TEST="true"
   - osx_image: xcode11.2
     # We can't run tests on macOS because CacheAdvance supports a minimum of macOS 10.15, and Travis CI's machines run on macOS 10.14.
-    env: ACTION="swift-package";SDK="macosx10.15";DESTINATION="platform=OS X";BUILD="build"
+    env: ACTION="swift-package";SDK="macosx10.15";DESTINATION="platform=OS X";SHOULD_TEST="false"
   - osx_image: xcode11.2
-    env: ACTION="swift-package";SDK="watchos6.1";DESTINATION="";BUILD="build"
+    env: ACTION="swift-package";SDK="watchos6.1";DESTINATION="";SHOULD_TEST="false"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ matrix:
   - osx_image: xcode11.2
     env: ACTION="swift-package";SDK="iphonesimulator";DESTINATION="platform=iOS Simulator,OS=13.2.2,name=iPad Pro (12.9-inch) (3rd generation)";SHOULD_TEST="true"
   - osx_image: xcode11.2
-    env: ACTION="swift-package";SDK="appletvsimulator13.2";DESTINATION="platform=tvOS Simulator,name=Apple TV";SHOULD_TEST="true"
+    env: ACTION="swift-package";SDK="appletvsimulator13.2";DESTINATION="platform=tvOS Simulator,name=Apple TV";SHOULD_TEST="true";ENABLE_CODE_COVERAGE="true"
+    after_success:
+      sh <(curl -s https://codecov.io/bash) -J '^CacheAdvance$' -D .build/derivedData -t 8344b011-6b2a-4b3d-a573-eaf49684318e
   - osx_image: xcode11.2
     # We can't run tests on macOS because CacheAdvance supports a minimum of macOS 10.15, and Travis CI's machines run on macOS 10.14.
     env: ACTION="swift-package";SDK="macosx10.15";DESTINATION="platform=OS X";SHOULD_TEST="false"

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-// Usage: build.swift sdk destination should_test
+// Usage: build.swift sdk destination should_test?
 
 func execute(commandPath: String, arguments: [String]) throws {
     let task = Process()
@@ -20,8 +20,8 @@ enum TaskError: Error {
     case code(Int32)
 }
 
-guard CommandLine.arguments.count == 4 else {
-    print("Usage: build.swift sdk destination should_test")
+guard CommandLine.arguments.count > 3 else {
+    print("Usage: build.swift sdk destination should_test?")
     throw TaskError.code(1)
 }
 
@@ -29,10 +29,7 @@ try execute(commandPath: "/usr/bin/swift", arguments: ["package", "generate-xcod
 
 let sdk = CommandLine.arguments[1]
 let destination = CommandLine.arguments[2]
-guard let shouldTest = Bool(CommandLine.arguments[3]) else {
-    print("Usage: should_test argument should be a boolean")
-    throw TaskError.code(2)
-}
+let shouldTest = CommandLine.arguments.count > 3 ? Bool(CommandLine.arguments[3]) ?? false : false
 
 var xcodeBuildArguments = [
     "-project", "generated/CacheAdvance.xcodeproj",

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -1,0 +1,53 @@
+#!/usr/bin/env swift
+
+import Foundation
+
+// Usage: build.swift sdk destination should_test
+
+func execute(commandPath: String, arguments: [String]) throws {
+    let task = Process()
+    task.launchPath = commandPath
+    task.arguments = arguments
+    print("Launching command: \(commandPath) \(arguments.joined(separator: " "))")
+    task.launch()
+    task.waitUntilExit()
+    guard task.terminationStatus == 0 else {
+        throw TaskError.code(task.terminationStatus)
+    }
+}
+
+enum TaskError: Error {
+    case code(Int32)
+}
+
+guard CommandLine.arguments.count == 4 else {
+    print("Usage: build.swift sdk destination should_test")
+    throw TaskError.code(1)
+}
+
+try execute(commandPath: "/usr/bin/swift", arguments: ["package", "generate-xcodeproj", "--output=generated/"])
+
+let sdk = CommandLine.arguments[1]
+let destination = CommandLine.arguments[2]
+guard let shouldTest = Bool(CommandLine.arguments[3]) else {
+    print("Usage: should_test argument should be a boolean")
+    throw TaskError.code(2)
+}
+
+var xcodeBuildArguments = [
+    "-project", "generated/CacheAdvance.xcodeproj",
+    "-scheme", "CacheAdvance-Package",
+    "-sdk", sdk,
+    "-configuration", "Release",
+    "-PBXBuildsContinueAfterErrors=0",
+]
+if !destination.isEmpty {
+    xcodeBuildArguments.append("-destination")
+    xcodeBuildArguments.append(destination)
+}
+xcodeBuildArguments.append("build")
+if shouldTest {
+    xcodeBuildArguments.append("test")
+}
+
+try execute(commandPath: "/usr/bin/xcodebuild", arguments: xcodeBuildArguments)

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -21,7 +21,7 @@ enum TaskError: Error {
 }
 
 guard CommandLine.arguments.count > 3 else {
-    print("Usage: build.swift sdk destination should_test?")
+    print("Usage: build.swift sdk destination should_test? enable_code_coverage?")
     throw TaskError.code(1)
 }
 
@@ -30,6 +30,7 @@ try execute(commandPath: "/usr/bin/swift", arguments: ["package", "generate-xcod
 let sdk = CommandLine.arguments[1]
 let destination = CommandLine.arguments[2]
 let shouldTest = CommandLine.arguments.count > 3 ? Bool(CommandLine.arguments[3]) ?? false : false
+let enableCodeCoverage = CommandLine.arguments.count > 4 ? Bool(CommandLine.arguments[4]) ?? false : false
 
 var xcodeBuildArguments = [
     "-project", "generated/CacheAdvance.xcodeproj",
@@ -41,6 +42,12 @@ var xcodeBuildArguments = [
 if !destination.isEmpty {
     xcodeBuildArguments.append("-destination")
     xcodeBuildArguments.append(destination)
+}
+if enableCodeCoverage {
+    xcodeBuildArguments.append("-enableCodeCoverage")
+    xcodeBuildArguments.append("YES")
+    xcodeBuildArguments.append("-derivedDataPath")
+    xcodeBuildArguments.append(".build/derivedData")
 }
 xcodeBuildArguments.append("build")
 if shouldTest {

--- a/Scripts/ci.sh
+++ b/Scripts/ci.sh
@@ -5,7 +5,7 @@ set -ex
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [ $ACTION == "swift-package" ]; then
-  $DIR/build.swift $SDK "$DESTINATION" $SHOULD_TEST
+  $DIR/build.swift $SDK "$DESTINATION" $SHOULD_TEST $ENABLE_CODE_COVERAGE
 fi
 
 if [ $ACTION == "pod-lint" ]; then

--- a/Scripts/ci.sh
+++ b/Scripts/ci.sh
@@ -1,26 +1,11 @@
 #!/bin/bash -l
 set -ex
 
+# Find the directory in which this script resides.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 if [ $ACTION == "swift-package" ]; then
-  swift package generate-xcodeproj --output generated/
-  if [ -n "$DESTINATION" ]; then
-    xcodebuild \
-      -project generated/CacheAdvance.xcodeproj \
-      -scheme "CacheAdvance-Package" \
-      -sdk $SDK \
-      -destination "$DESTINATION" \
-      -configuration Release \
-      -PBXBuildsContinueAfterErrors=0 \
-      $BUILD
-  else
-    xcodebuild \
-      -project generated/CacheAdvance.xcodeproj \
-      -scheme "CacheAdvance-Package" \
-      -sdk $SDK \
-      -configuration Release \
-      -PBXBuildsContinueAfterErrors=0 \
-      $BUILD
-  fi
+  $DIR/build.swift $SDK "$DESTINATION" $SHOULD_TEST
 fi
 
 if [ $ACTION == "pod-lint" ]; then


### PR DESCRIPTION
Bash makes programmatically composing flags in a command-line utility quite difficult. In order to make our build script more flexible, this PR migrates the script that creates the `xcodebuild` command from bash to swift.

~This will make it easier to add a flag for enabling code coverage.~ This PR also adds code-coverage reporting.

This PR resolves #6.