### PR TITLE
Specify BigEndianHostSwappable-conforming objects should already be FixedWidthInteger

### DIFF
--- a/Sources/CacheAdvance/BigEndianHostSwappable.swift
+++ b/Sources/CacheAdvance/BigEndianHostSwappable.swift
@@ -18,7 +18,7 @@
 import Foundation
 
 /// A protocol representing an integer that can be encoded as data.
-protocol BigEndianHostSwappable: FixedWidthInteger {
+protocol BigEndianHostSwappable where Self: FixedWidthInteger {
 
     /// Converts the big-endian value in x to the current endian format and returns the resulting value.
     static func swapToHost(_ x: Self) -> Self


### PR DESCRIPTION
Addresses https://github.com/dfed/CacheAdvance/pull/15#commitcomment-36320000

@fdiaz @bachand