### PR TITLE
Do not build branch build on every push on PR branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,7 @@ matrix:
     env: ACTION="pod-lint";SWIFT_VERSION="5.1"
   - osx_image: xcode11.2
     env: ACTION="carthage"
+
+branches:
+  only:
+  - master


### PR DESCRIPTION
We don't need to build both a `pr` build and a `push` build on every pull request. This PR makes it so we only build `push` builds for `master`. We'll still have PR builds on every PR, but we won't build every PR build twice.

See [Travis's docs](https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches) for more info on this change.

cc @bachand