### PR TITLE
Provide development instructions and ignore Xcode projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,5 @@ DerivedData
 generated/
 *coverage.txt
 
-# We can generate the project from the package. No need to check it in.
+# We can generate Xcode projects from the Swift packages.
 *.xcodeproj/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ DerivedData
 .swiftpm/
 generated/
 *coverage.txt
+
+# We can generate the project from the package. No need to check it in.
+CacheAdvance.xcodeproj/

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ generated/
 *coverage.txt
 
 # We can generate the project from the package. No need to check it in.
-CacheAdvance.xcodeproj/
+*.xcodeproj/

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ I’m glad you’re interested in CacheAdvance, and I’d love to see where you 
 
 Thanks, and happy caching!
 
+## Developing
+
+Run `swift package generate-xcodeproj` from the root of the repository to generate an Xcode project.
+
 ## Attribution
 
 Shout out to [Peter Westen](https://twitter.com/pwesten) who inspired the creation of this library.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Thanks, and happy caching!
 
 ## Developing
 
-Run `swift package generate-xcodeproj` from the root of the repository to generate an Xcode project.
+Double-click on `Package.swift` in the root of the repository to open the project in Xcode.
 
 ## Attribution
 


### PR DESCRIPTION
I ran `swift package generate-xcodeproj` from the root of the repo. That generated `CacheAdvance.xcodeproj`, which I can use to build and run this project.

Since we can generate this project from the package, it seems like we don't need to check it in.

While I was at it, I added a section on Developing to the README, and described how to get a working Xcode project.

Please let me know if I'm doing anything in a non-standard way. I was interested in poking around the code in my IDE and this is how I would normally get started.