### PR TITLE
Use one machine to get code coverage for two jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,9 @@ matrix:
     env: ACTION="swift-package";PLATFORMS="iOS_12,iOS_13";
 
   - osx_image: xcode11.2
-    env: ACTION="swift-package";PLATFORMS="tvOS_12";
+    env: ACTION="swift-package";PLATFORMS="tvOS_12,tvOS_13";
     after_success:
-      bash <(curl -s https://codecov.io/bash) -J '^CacheAdvance$' -D .build/derivedData -t 8344b011-6b2a-4b3d-a573-eaf49684318e
-  - osx_image: xcode11.2
-    env: ACTION="swift-package";PLATFORMS="tvOS_13";
-    after_success:
-      bash <(curl -s https://codecov.io/bash) -J '^CacheAdvance$' -D .build/derivedData -t 8344b011-6b2a-4b3d-a573-eaf49684318e
+      bash <(curl -s https://codecov.io/bash) -J '^CacheAdvance$' -D .build/derivedData/tvOS_12 -t 8344b011-6b2a-4b3d-a573-eaf49684318e && bash <(curl -s https://codecov.io/bash) -J '^CacheAdvance$' -D .build/derivedData/tvOS_13 -t 8344b011-6b2a-4b3d-a573-eaf49684318e
 
   - osx_image: xcode11.2
     env: ACTION="swift-package";PLATFORMS="macOS_10_15";

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ matrix:
   - osx_image: xcode11.2
     env: ACTION="swift-package";PLATFORMS="tvOS_12,tvOS_13";
     after_success:
-      bash <(curl -s https://codecov.io/bash) -J '^CacheAdvance$' -D .build/derivedData/tvOS_12 -t 8344b011-6b2a-4b3d-a573-eaf49684318e && bash <(curl -s https://codecov.io/bash) -J '^CacheAdvance$' -D .build/derivedData/tvOS_13 -t 8344b011-6b2a-4b3d-a573-eaf49684318e
+      - bash <(curl -s https://codecov.io/bash) -J '^CacheAdvance$' -D .build/derivedData/tvOS_12 -t 8344b011-6b2a-4b3d-a573-eaf49684318e
+      - bash <(curl -s https://codecov.io/bash) -J '^CacheAdvance$' -D .build/derivedData/tvOS_13 -t 8344b011-6b2a-4b3d-a573-eaf49684318e
 
   - osx_image: xcode11.2
     env: ACTION="swift-package";PLATFORMS="macOS_10_15";

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ matrix:
   include:
   - osx_image: xcode11.2
     env: ACTION="swift-package";PLATFORMS="iOS_12,iOS_13";
+    after_success:
+      - bash <(curl -s https://codecov.io/bash) -J '^CacheAdvance$' -D .build/derivedData/iOS_12 -t 8344b011-6b2a-4b3d-a573-eaf49684318e
+      - bash <(curl -s https://codecov.io/bash) -J '^CacheAdvance$' -D .build/derivedData/iOS_13 -t 8344b011-6b2a-4b3d-a573-eaf49684318e
 
   - osx_image: xcode11.2
     env: ACTION="swift-package";PLATFORMS="tvOS_12,tvOS_13";
@@ -17,6 +20,8 @@ matrix:
 
   - osx_image: xcode11.2
     env: ACTION="swift-package";PLATFORMS="macOS_10_15";
+    after_success:
+      - bash <(curl -s https://codecov.io/bash) -J '^CacheAdvance$' -D .build/derivedData/macOS_10_15 -t 8344b011-6b2a-4b3d-a573-eaf49684318e
 
   - osx_image: xcode11.2
     env: ACTION="swift-package";PLATFORMS="watchOS_5,watchOS_6";

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -86,22 +86,6 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
         }
     }
 
-    var enableCodeCoverage: Bool {
-        switch self {
-        case .tvOS_12,
-             .tvOS_13:
-            // We currently only have a after_success job to upload code coverage for our tvOS targets.
-            return true
-
-        case .iOS_12,
-             .iOS_13,
-             .macOS_10_15,
-             .watchOS_5,
-             .watchOS_6:
-            return false
-        }
-    }
-
     var derivedDataPath: String {
         ".build/derivedData/" + description
     }
@@ -137,7 +121,7 @@ for rawPlatform in rawPlatforms {
         xcodeBuildArguments.append("-destination")
         xcodeBuildArguments.append(platform.destination)
     }
-    if platform.enableCodeCoverage {
+    if platform.shouldTest {
         xcodeBuildArguments.append("-enableCodeCoverage")
         xcodeBuildArguments.append("YES")
         xcodeBuildArguments.append("-derivedDataPath")

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -115,6 +115,7 @@ for rawPlatform in rawPlatforms {
         "-scheme", "CacheAdvance-Package",
         "-sdk", platform.sdk,
         "-configuration", "Release",
+        "-derivedDataPath", platform.derivedDataPath,
         "-PBXBuildsContinueAfterErrors=0",
     ]
     if !platform.destination.isEmpty {
@@ -124,8 +125,6 @@ for rawPlatform in rawPlatforms {
     if platform.shouldTest {
         xcodeBuildArguments.append("-enableCodeCoverage")
         xcodeBuildArguments.append("YES")
-        xcodeBuildArguments.append("-derivedDataPath")
-        xcodeBuildArguments.append(platform.derivedDataPath)
     }
     xcodeBuildArguments.append("build")
     if platform.shouldTest {

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -102,6 +102,10 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
         }
     }
 
+    var derivedDataPath: String {
+        ".build/derivedData/" + description
+    }
+
     var description: String {
         rawValue
     }
@@ -137,7 +141,7 @@ for rawPlatform in rawPlatforms {
         xcodeBuildArguments.append("-enableCodeCoverage")
         xcodeBuildArguments.append("YES")
         xcodeBuildArguments.append("-derivedDataPath")
-        xcodeBuildArguments.append(".build/derivedData")
+        xcodeBuildArguments.append(platform.derivedDataPath)
     }
     xcodeBuildArguments.append("build")
     if platform.shouldTest {


### PR DESCRIPTION
In this PR I try to use a single travis configuration to get code coverage for multiple builds. This should hopefully improve the reliability of the code coverage comment, preventing issues like https://github.com/dfed/CacheAdvance/pull/25#issuecomment-574007303.

Since we can now upload test coverage for multiple jobs on the same machine, it seemed reasonable to enable test coverage on more jobs.