### PR TITLE
Extract header validation logic into its own method

### DIFF
--- a/Sources/CacheAdvance/CacheHeaderHandle.swift
+++ b/Sources/CacheAdvance/CacheHeaderHandle.swift
@@ -78,7 +78,7 @@ final class CacheHeaderHandle {
     /// - Parameter fileHeader: A representation of the header data in an existing cache file.
     ///
     /// - Returns: `true` if this object's static metadata matches that of `fileHeader`; otherwise `false`.
-    func validateMetadata(against fileHeader: FileHeader) -> Bool {
+    func canOpenFile(with fileHeader: FileHeader) -> Bool {
         guard fileHeader.version == version else {
             // Our current file header version is 1.
             // That means there is no prior header version we could attempt to read.
@@ -118,7 +118,7 @@ final class CacheHeaderHandle {
                 return
             }
 
-            guard validateMetadata(against: fileHeader) else {
+            guard canOpenFile(with: fileHeader) else {
                 // The header is invalid. Nuke it.
                 try resetFile()
                 return

--- a/Tests/CacheAdvanceTests/CacheHeaderHandleTests.swift
+++ b/Tests/CacheAdvanceTests/CacheHeaderHandleTests.swift
@@ -97,6 +97,8 @@ final class CacheHeaderHandleTests: XCTestCase {
         try handle.seek(to: 0)
         let headerData = try handle.readDataUp(toLength: Int(FileHeader.expectedEndOfHeaderInFile))
         XCTAssertEqual(headerData.count, Int(FileHeader.expectedEndOfHeaderInFile))
+
+        try handle.closeHandle()
     }
 
     func test_validateMetadata_versionMismatch_returnsFalse() throws {

--- a/Tests/CacheAdvanceTests/CacheHeaderHandleTests.swift
+++ b/Tests/CacheAdvanceTests/CacheHeaderHandleTests.swift
@@ -90,8 +90,8 @@ final class CacheHeaderHandleTests: XCTestCase {
         let handle = try FileHandle(forUpdating: testFileLocation)
         handle.write(Data(repeating: 0, count: Int(FileHeader.expectedEndOfHeaderInFile) - 1))
 
-        let headerHandle1 = try createHeaderHandle()
-        try headerHandle1.synchronizeHeaderData()
+        let headerHandle = try createHeaderHandle()
+        try headerHandle.synchronizeHeaderData()
 
         // Verify that the file is now the size of the header. This means that we rewrote the file.
         try handle.seek(to: 0)

--- a/Tests/CacheAdvanceTests/CacheHeaderHandleTests.swift
+++ b/Tests/CacheAdvanceTests/CacheHeaderHandleTests.swift
@@ -101,7 +101,7 @@ final class CacheHeaderHandleTests: XCTestCase {
         try handle.closeHandle()
     }
 
-    func test_validateMetadata_versionMismatch_returnsFalse() throws {
+    func test_canOpenFile_versionMismatch_returnsFalse() throws {
         let fileHeader = FileHeader(
             version: 1,
             maximumBytes: 1000,
@@ -114,10 +114,10 @@ final class CacheHeaderHandleTests: XCTestCase {
             overwritesOldMessages: true,
             version: 2)
 
-        XCTAssertFalse(sut.validateMetadata(against: fileHeader))
+        XCTAssertFalse(sut.canOpenFile(with: fileHeader))
     }
 
-    func test_validateMetadata_maximumBytesMismatch_returnsFalse() throws {
+    func test_canOpenFile_maximumBytesMismatch_returnsFalse() throws {
         let fileHeader = FileHeader(
             version: 1,
             maximumBytes: 1000,
@@ -130,10 +130,10 @@ final class CacheHeaderHandleTests: XCTestCase {
             overwritesOldMessages: true,
             version: 1)
 
-        XCTAssertFalse(sut.validateMetadata(against: fileHeader))
+        XCTAssertFalse(sut.canOpenFile(with: fileHeader))
     }
 
-    func test_validateMetadata_overwritesOldMessagesMismatch_returnsFalse() throws {
+    func test_canOpenFile_overwritesOldMessagesMismatch_returnsFalse() throws {
         let fileHeader = FileHeader(
             version: 1,
             maximumBytes: 1000,
@@ -146,10 +146,10 @@ final class CacheHeaderHandleTests: XCTestCase {
             overwritesOldMessages: false,
             version: 1)
 
-        XCTAssertFalse(sut.validateMetadata(against: fileHeader))
+        XCTAssertFalse(sut.canOpenFile(with: fileHeader))
     }
 
-    func test_validateMetadata_noMismatches_returnsTrue() throws {
+    func test_canOpenFile_noMismatches_returnsTrue() throws {
         let fileHeader = FileHeader(
             version: 1,
             maximumBytes: 1000,
@@ -162,7 +162,7 @@ final class CacheHeaderHandleTests: XCTestCase {
             overwritesOldMessages: true,
             version: 1)
 
-        XCTAssertTrue(sut.validateMetadata(against: fileHeader))
+        XCTAssertTrue(sut.canOpenFile(with: fileHeader))
     }
 
     // MARK: Private

--- a/Tests/CacheAdvanceTests/CacheHeaderHandleTests.swift
+++ b/Tests/CacheAdvanceTests/CacheHeaderHandleTests.swift
@@ -85,6 +85,70 @@ final class CacheHeaderHandleTests: XCTestCase {
         XCTAssertEqual(headerHandle2.offsetInFileOfOldestMessage, defaultOffsetInFileOfOldestMessage)
     }
 
+    func test_validateMetadata_versionMismatch_returnsFalse() throws {
+        let fileHeader = FileHeader(
+            version: 1,
+            maximumBytes: 1000,
+            overwritesOldMessages: true,
+            offsetInFileOfOldestMessage: FileHeader.expectedEndOfHeaderInFile,
+            offsetInFileAtEndOfNewestMessage: 500)
+
+        let sut = try createHeaderHandle(
+            maximumBytes: 1000,
+            overwritesOldMessages: true,
+            version: 2)
+
+        XCTAssertFalse(sut.validateMetadata(against: fileHeader))
+    }
+
+    func test_validateMetadata_maximumBytesMismatch_returnsFalse() throws {
+        let fileHeader = FileHeader(
+            version: 1,
+            maximumBytes: 1000,
+            overwritesOldMessages: true,
+            offsetInFileOfOldestMessage: FileHeader.expectedEndOfHeaderInFile,
+            offsetInFileAtEndOfNewestMessage: 500)
+
+        let sut = try createHeaderHandle(
+            maximumBytes: 2000,
+            overwritesOldMessages: true,
+            version: 1)
+
+        XCTAssertFalse(sut.validateMetadata(against: fileHeader))
+    }
+
+    func test_validateMetadata_overwritesOldMessagesMismatch_returnsFalse() throws {
+        let fileHeader = FileHeader(
+            version: 1,
+            maximumBytes: 1000,
+            overwritesOldMessages: true,
+            offsetInFileOfOldestMessage: FileHeader.expectedEndOfHeaderInFile,
+            offsetInFileAtEndOfNewestMessage: 500)
+
+        let sut = try createHeaderHandle(
+            maximumBytes: 1000,
+            overwritesOldMessages: false,
+            version: 1)
+
+        XCTAssertFalse(sut.validateMetadata(against: fileHeader))
+    }
+
+    func test_validateMetadata_noMismatches_returnsTrue() throws {
+        let fileHeader = FileHeader(
+            version: 1,
+            maximumBytes: 1000,
+            overwritesOldMessages: true,
+            offsetInFileOfOldestMessage: FileHeader.expectedEndOfHeaderInFile,
+            offsetInFileAtEndOfNewestMessage: 500)
+
+        let sut = try createHeaderHandle(
+            maximumBytes: 1000,
+            overwritesOldMessages: true,
+            version: 1)
+
+        XCTAssertTrue(sut.validateMetadata(against: fileHeader))
+    }
+
     // MARK: Private
 
     private func createHeaderHandle(


### PR DESCRIPTION
In a previous PR we have discussed adding a public `validateHeader()` method: https://github.com/dfed/CacheAdvance/pull/22#discussion_r362097709

Right now if you instantiate a `CacheAdvance` object with metadata that doesn't match the metadata of an existing cache file, we reset that file.

Ideally we would have public API that allows you to first check if the file matches the metadata you are supplying, in order to prevent unexpected data loss.

This PR does not add a `validateHeader()` method. But by extracting the existing validation logic into its own method we're one step closer.