### PR TITLE
Simplify and refactor `synchronizeHeaderData()` in preparation for `isCompatible(...)` method

### DIFF
--- a/Sources/CacheAdvance/CacheHeaderHandle.swift
+++ b/Sources/CacheAdvance/CacheHeaderHandle.swift
@@ -114,26 +114,20 @@ final class CacheHeaderHandle {
     func synchronizeHeaderData() throws {
         let headerData = try readHeaderData()
 
-        if headerData.isEmpty {
-            // There is no header. Write one to disk.
-            try writeHeaderData()
-
-        } else {
-            guard let fileHeader = FileHeader(from: headerData) else {
-                // We can't read the header data. Let's start over.
-                try resetFile()
-                return
-            }
-
-            guard canOpenFile(with: fileHeader) else {
-                // The header is invalid. Nuke it.
-                try resetFile()
-                return
-            }
-
-            self.offsetInFileOfOldestMessage = fileHeader.offsetInFileOfOldestMessage
-            self.offsetInFileAtEndOfNewestMessage = fileHeader.offsetInFileAtEndOfNewestMessage
+        guard let fileHeader = FileHeader(from: headerData) else {
+            // We can't read the header data. Let's start over.
+            try resetFile()
+            return
         }
+
+        guard canOpenFile(with: fileHeader) else {
+            // The header is invalid. Nuke it.
+            try resetFile()
+            return
+        }
+
+        self.offsetInFileOfOldestMessage = fileHeader.offsetInFileOfOldestMessage
+        self.offsetInFileAtEndOfNewestMessage = fileHeader.offsetInFileAtEndOfNewestMessage
     }
 
     // MARK: Private

--- a/Sources/CacheAdvance/CacheHeaderHandle.swift
+++ b/Sources/CacheAdvance/CacheHeaderHandle.swift
@@ -52,6 +52,17 @@ final class CacheHeaderHandle {
     private(set) var offsetInFileOfOldestMessage: UInt64
     private(set) var offsetInFileAtEndOfNewestMessage: UInt64
 
+    /// Attempts to read the header data of the file.
+    ///
+    /// - Returns: As much of the header data as exists. The returned data may not form a complete header.
+    func readHeaderData() throws -> Data {
+        // Start at the beginning of the file.
+        try handle.seek(to: 0)
+
+        // Read the entire header.
+        return try handle.readDataUp(toLength: Int(FileHeader.expectedEndOfHeaderInFile))
+    }
+
     func updateOffsetInFileOfOldestMessage(to offset: UInt64) throws {
         offsetInFileOfOldestMessage = offset
 
@@ -101,11 +112,7 @@ final class CacheHeaderHandle {
     /// Reads the header data from the file. Writes header information to disk if no header exists.
     /// If the header data persisted to the file is not consistent with expectations, the file will be deleted.
     func synchronizeHeaderData() throws {
-        // Start at the beginning of the file.
-        try handle.seek(to: 0)
-
-        // Read the entire header.
-        let headerData = try handle.readDataUp(toLength: Int(FileHeader.expectedEndOfHeaderInFile))
+        let headerData = try readHeaderData()
 
         if headerData.isEmpty {
             // There is no header. Write one to disk.

--- a/Tests/CacheAdvanceTests/CacheHeaderHandleTests.swift
+++ b/Tests/CacheAdvanceTests/CacheHeaderHandleTests.swift
@@ -85,6 +85,22 @@ final class CacheHeaderHandleTests: XCTestCase {
         XCTAssertEqual(headerHandle2.offsetInFileOfOldestMessage, defaultOffsetInFileOfOldestMessage)
     }
 
+    func test_synchronizeHeaderData_resetsFileWhenFileIsEmpty() throws {
+        let handle = try FileHandle(forReadingFrom: testFileLocation)
+        let fileData = try handle.readDataUp(toLength: 1)
+        XCTAssertTrue(fileData.isEmpty)
+
+        let headerHandle = try createHeaderHandle()
+        try headerHandle.synchronizeHeaderData()
+
+        // Verify that the file is now the size of the header. This means that we rewrote the file.
+        try handle.seek(to: 0)
+        let headerData = try handle.readDataUp(toLength: Int(FileHeader.expectedEndOfHeaderInFile))
+        XCTAssertEqual(headerData.count, Int(FileHeader.expectedEndOfHeaderInFile))
+
+        try handle.closeHandle()
+    }
+
     func test_synchronizeHeaderData_resetsFileWhenFileHeaderCannotBeCreated() throws {
         // Write a file that is too short for us to parse a `FileHeader` object.
         let handle = try FileHandle(forUpdating: testFileLocation)


### PR DESCRIPTION
I'm planning to add an `isCompatible(...)` public method to the `CacheAdvance` type. See the code at the bottom of this PR message. I almost finished adding it in this PR, but I'm trying to think about how to avoid duplicating too much logic between tests and I ran out of time now. Many of the same tests that we added for the `canOpenFile(...)` method (see https://github.com/dfed/CacheAdvance/pull/28) would apply here as well. Any ideas would be appreciated. Also I welcome any feedback on this method before I put up that PR.

This PR further refactors `CacheHeaderHandle` in preparation for adding the `isCompatible(...)` method. I've extracted the code that reads the data for the header into its own method. Previously we had a separate code path for resetting the file if it is empty. I added at test for that case and then removed that code path in favor of the code we already had, which would do what we wanted.

----

```swift
public static func isCompatible(
    withFile file: URL,
    maximumBytes: Bytes,
    shouldOverwriteOldMessages: Bool)
    throws -> Bool
{
    let cacheHeaderHandle = try CacheHeaderHandle(
        forReadingFrom: file,
        maximumBytes: maximumBytes,
        overwritesOldMessages: shouldOverwriteOldMessages)

    let headerData = try cacheHeaderHandle.readHeaderData()

    guard let fileHeader = FileHeader(from: headerData) else {
        // We can't read the header data. This is definitely not compatible.
        return false
    }

    guard cacheHeaderHandle.canOpenFile(with: fileHeader) else {
        // The header is incompatible.
        return false
    }

    return true
}
```