### PR TITLE
Clearly separate cache full error from message too large error

### DIFF
--- a/Sources/CacheAdvance/CacheAdvance.swift
+++ b/Sources/CacheAdvance/CacheAdvance.swift
@@ -70,7 +70,7 @@ public final class CacheAdvance<T: Codable> {
             else
         {
             // The message is too long to be written to a cache of this size.
-            throw CacheAdvanceError.messageDataTooLarge
+            throw CacheAdvanceError.messageLargerThanCacheCapacity
         }
 
         let cacheHasSpaceForNewMessageBeforeEndOfFile = writer.offsetInFile + bytesNeededToStoreMessage <= maximumBytes
@@ -115,7 +115,7 @@ public final class CacheAdvance<T: Codable> {
 
         } else {
             // We're out of room.
-            throw CacheAdvanceError.messageDataTooLarge
+            throw CacheAdvanceError.messageLargerThanRemainingCacheSize
         }
     }
 

--- a/Sources/CacheAdvance/CacheAdvanceError.swift
+++ b/Sources/CacheAdvance/CacheAdvanceError.swift
@@ -16,8 +16,10 @@
 //
 
 public enum CacheAdvanceError: Error, Equatable {
-    /// Thrown when the message being appended is larger than maximum bytes.
-    case messageDataTooLarge
+    /// Thrown when the message being appended is too large to be stored in a cache of this size.
+    case messageLargerThanCacheCapacity
+    /// Thrown when a message being appended to a cache that does not overwrite old messages is too large to store in the remaining space.
+    case messageLargerThanRemainingCacheSize
     /// Thrown when the cache file is of an unexpected format.
     /// A corrupted file should be deleted. Corruption can occur if an application crashes while writing to the file.
     case fileCorrupted

--- a/Sources/CacheAdvance/EncodableMessage.swift
+++ b/Sources/CacheAdvance/EncodableMessage.swift
@@ -42,7 +42,7 @@ struct EncodableMessage<T: Codable> {
         let messageData = try encoder.encode(message)
         guard messageData.count < MessageSpan.max else {
             // We can't encode the length this message in a MessageSpan.
-            throw CacheAdvanceError.messageDataTooLarge
+            throw CacheAdvanceError.messageLargerThanCacheCapacity
         }
         let encodedSize = Data(MessageSpan(messageData.count))
         return encodedSize + messageData

--- a/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
+++ b/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
@@ -52,7 +52,7 @@ final class CacheAdvanceTests: XCTestCase {
         let cache = try createCache(messages: [message], maximumByteSubtractor: 1)
 
         XCTAssertThrowsError(try cache.append(message: message)) {
-            XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.messageDataTooLarge)
+            XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.messageLargerThanCacheCapacity)
         }
 
         let messages = try cache.messages()
@@ -64,7 +64,7 @@ final class CacheAdvanceTests: XCTestCase {
         let cache = try createCache(messages: [message], shouldOverwriteOldMessages: true, maximumByteSubtractor: 1)
 
         XCTAssertThrowsError(try cache.append(message: message)) {
-            XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.messageDataTooLarge)
+            XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.messageLargerThanCacheCapacity)
         }
 
         let messages = try cache.messages()
@@ -106,7 +106,7 @@ final class CacheAdvanceTests: XCTestCase {
         }
 
         XCTAssertThrowsError(try cache.append(message: "This message won't fit")) {
-            XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.messageDataTooLarge)
+            XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.messageLargerThanRemainingCacheSize)
         }
 
         let messages = try cache.messages()


### PR DESCRIPTION
When trying to adopt this project, I realized that we had conflated two similar errors that required differentiated error handling. `messageDataTooLarge` covered both "this message could never fit in this cache" and "the remaining space left in the cache can't fit this message".

In this PR, I separate this case into two separate errors.

This is a source-breaking change. Our next version will need to be 0.2.0 if we merge this PR as-is.