### PR TITLE
Expose CacheReader to enable a more-explict read-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ let cachedMessages = try myCache.messages()
 
 This method reads all cached messages from disk into memory.
 
+If you want to read messages that were previously cached and do not need to write new messages, you can utilize a `CacheReader` to read all cached messages into memory:
+
+```swift
+let myReader = try CacheReader(fileURL: FileManager.default.temporaryDirectory.appendingPathComponent("MyCache"))
+let cachedMessages = try myReader.messages()
+```
+
 ### Thread safety
 
 CacheAdvances are not thread safe: a single CacheAdvance instance should always be interacted with from a single, serial queue. Since CacheAdvance reads from and writes to the disk synchronously, it is best to interact with a CacheAdvance on a background queue to prevent blocking the main queue.

--- a/Sources/CacheAdvance/CacheHeaderHandle.swift
+++ b/Sources/CacheAdvance/CacheHeaderHandle.swift
@@ -24,18 +24,19 @@ final class CacheHeaderHandle {
     /// Creates a new instance of the receiver.
     ///
     /// - Parameters:
-    ///   - file: The file URL indicating the desired location of the on-disk store. This file should already exist.
+    ///   - fileURL: The file URL indicating the desired location of the on-disk store. This file should already exist.
     ///   - maximumBytes: The maximum size of the cache, in bytes. Logs larger than this size will fail to append to the store.
     ///   - overwritesOldMessages: When `true`,  the cache encodes a pointer to the oldest message after the newest message marker.
     ///   - version: The file's expected header version.
     init(
-        forReadingFrom file: URL,
+        forReadingFrom fileURL: URL,
         maximumBytes: Bytes,
         overwritesOldMessages: Bool,
         version: UInt8 = FileHeader.version)
         throws
     {
-        handle = try FileHandle(forUpdating: file)
+        self.fileURL = fileURL
+        handle = try FileHandle(forUpdating: fileURL)
         self.maximumBytes = maximumBytes
         self.overwritesOldMessages = overwritesOldMessages
         self.version = version
@@ -49,6 +50,7 @@ final class CacheHeaderHandle {
 
     // MARK: Internal
 
+    let fileURL: URL
     let maximumBytes: Bytes
     let overwritesOldMessages: Bool
     private(set) var offsetInFileOfOldestMessage: UInt64

--- a/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
+++ b/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
@@ -25,14 +25,14 @@ final class CacheAdvanceTests: XCTestCase {
     // MARK: Behavior Tests
 
     func test_isEmpty_returnsTrueWhenCacheIsEmpty() throws {
-        let cache = try createCache(overwritesOldMessages: false)
+        let cache = try Self.createCache(overwritesOldMessages: false)
 
         XCTAssertTrue(try cache.isEmpty())
     }
 
     func test_isEmpty_returnsFalseWhenCacheHasASingleMessage() throws {
         let message: TestableMessage = "This is a test"
-        let cache = try createCache(sizedToFit: [message], overwritesOldMessages: false)
+        let cache = try Self.createCache(sizedToFit: [message], overwritesOldMessages: false)
         try cache.append(message: message)
 
         XCTAssertFalse(try cache.isEmpty())
@@ -40,24 +40,24 @@ final class CacheAdvanceTests: XCTestCase {
 
     func test_isEmpty_returnsFalseWhenOpenedOnCacheThatHasASingleMessage() throws {
         let message: TestableMessage = "This is a test"
-        let cache = try createCache(overwritesOldMessages: false)
+        let cache = try Self.createCache(overwritesOldMessages: false)
         try cache.append(message: message)
 
-        let sameCache = try createCache(overwritesOldMessages: false, zeroOutExistingFile: false)
+        let sameCache = try Self.createCache(overwritesOldMessages: false, zeroOutExistingFile: false)
 
         XCTAssertFalse(try sameCache.isEmpty())
     }
 
     func test_isEmpty_returnsFalseWhenCacheThatDoesNotOverwriteIsFull() throws {
         let message: TestableMessage = "This is a test"
-        let cache = try createCache(sizedToFit: [message], overwritesOldMessages: false)
+        let cache = try Self.createCache(sizedToFit: [message], overwritesOldMessages: false)
         try cache.append(message: message)
 
         XCTAssertFalse(try cache.isEmpty())
     }
 
     func test_isEmpty_returnsFalseWhenCacheThatOverwritesIsFull() throws {
-        let cache = try createCache(overwritesOldMessages: true)
+        let cache = try Self.createCache(overwritesOldMessages: true)
         for message in Self.lorumIpsumMessages {
             try cache.append(message: message)
         }
@@ -66,44 +66,44 @@ final class CacheAdvanceTests: XCTestCase {
     }
 
     func test_messages_canReadEmptyCacheThatDoesNotOverwriteOldestMessages() throws {
-        let cache = try createCache(overwritesOldMessages: false)
+        let cache = try Self.createCache(overwritesOldMessages: false)
 
         let messages = try cache.messages()
         XCTAssertEqual(messages, [])
     }
 
     func test_messages_canReadEmptyCacheThatOverwritesOldestMessages() throws {
-        let cache = try createCache(overwritesOldMessages: true)
+        let cache = try Self.createCache(overwritesOldMessages: true)
 
         let messages = try cache.messages()
         XCTAssertEqual(messages, [])
     }
 
     func test_isWritable_returnsTrueWhenStaticHeaderMetadataMatches() throws {
-        let originalCache = try createCache(overwritesOldMessages: false)
+        let originalCache = try Self.createCache(overwritesOldMessages: false)
         XCTAssertTrue(try originalCache.isWritable())
 
-        let sut = try createCache(overwritesOldMessages: false, zeroOutExistingFile: false)
+        let sut = try Self.createCache(overwritesOldMessages: false, zeroOutExistingFile: false)
         XCTAssertTrue(try sut.isWritable())
     }
 
     func test_isWritable_throwsFileCorruptedWhenHeaderVersionDoesNotMatch() throws {
-        let originalHeader = try createHeaderHandle(
+        let originalHeader = try Self.createHeaderHandle(
             overwritesOldMessages: false,
             version: 0)
         try originalHeader.synchronizeHeaderData()
 
-        let sut = try createCache(overwritesOldMessages: false, zeroOutExistingFile: false)
+        let sut = try Self.createCache(overwritesOldMessages: false, zeroOutExistingFile: false)
         XCTAssertThrowsError(try sut.isWritable()) {
             XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.fileCorrupted)
         }
     }
 
     func test_isWritable_returnsFalseWhenMaximumBytesDoesNotMatch() throws {
-        let originalCache = try createCache(overwritesOldMessages: false)
+        let originalCache = try Self.createCache(overwritesOldMessages: false)
         XCTAssertTrue(try originalCache.isWritable())
 
-        let sut = try createCache(
+        let sut = try Self.createCache(
             sizedToFit: Self.lorumIpsumMessages.dropLast(),
             overwritesOldMessages: false,
             zeroOutExistingFile: false)
@@ -111,16 +111,16 @@ final class CacheAdvanceTests: XCTestCase {
     }
 
     func test_isWritable_returnsFalseWhenOverwritesOldMessagesDoesNotMatch() throws {
-        let originalCache = try createCache(overwritesOldMessages: false)
+        let originalCache = try Self.createCache(overwritesOldMessages: false)
         XCTAssertTrue(try originalCache.isWritable())
 
-        let sut = try createCache(overwritesOldMessages: true, zeroOutExistingFile: false)
+        let sut = try Self.createCache(overwritesOldMessages: true, zeroOutExistingFile: false)
         XCTAssertFalse(try sut.isWritable())
     }
 
     func test_append_singleMessageThatFits_canBeRetrieved() throws {
         let message: TestableMessage = "This is a test"
-        let cache = try createCache(sizedToFit: [message], overwritesOldMessages: false)
+        let cache = try Self.createCache(sizedToFit: [message], overwritesOldMessages: false)
         try cache.append(message: message)
 
         let messages = try cache.messages()
@@ -129,7 +129,7 @@ final class CacheAdvanceTests: XCTestCase {
 
     func test_append_singleMessageThatDoesNotFit_throwsError() throws {
         let message: TestableMessage = "This is a test"
-        let cache = try createCache(sizedToFit: [message], overwritesOldMessages: false, maximumByteSubtractor: 1)
+        let cache = try Self.createCache(sizedToFit: [message], overwritesOldMessages: false, maximumByteSubtractor: 1)
 
         XCTAssertThrowsError(try cache.append(message: message)) {
             XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.messageLargerThanCacheCapacity)
@@ -141,7 +141,7 @@ final class CacheAdvanceTests: XCTestCase {
 
     func test_append_singleMessageThrowsIfDoesNotFitAndCacheRolls() throws {
         let message: TestableMessage = "This is a test"
-        let cache = try createCache(sizedToFit: [message], overwritesOldMessages: true, maximumByteSubtractor: 1)
+        let cache = try Self.createCache(sizedToFit: [message], overwritesOldMessages: true, maximumByteSubtractor: 1)
 
         XCTAssertThrowsError(try cache.append(message: message)) {
             XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.messageLargerThanCacheCapacity)
@@ -152,7 +152,7 @@ final class CacheAdvanceTests: XCTestCase {
     }
 
     func test_append_multipleMessagesCanBeRetrieved() throws {
-        let cache = try createCache(overwritesOldMessages: false)
+        let cache = try Self.createCache(overwritesOldMessages: false)
         for message in Self.lorumIpsumMessages {
             try cache.append(message: message)
         }
@@ -162,7 +162,7 @@ final class CacheAdvanceTests: XCTestCase {
     }
 
     func test_append_multipleMessagesCanBeRetrievedTwiceFromNonOverwritingCache() throws {
-        let cache = try createCache(overwritesOldMessages: false)
+        let cache = try Self.createCache(overwritesOldMessages: false)
         for message in Self.lorumIpsumMessages {
             try cache.append(message: message)
         }
@@ -171,7 +171,7 @@ final class CacheAdvanceTests: XCTestCase {
     }
 
     func test_append_multipleMessagesCanBeRetrievedTwiceFromOverwritingCache() throws {
-        let cache = try createCache(overwritesOldMessages: true, maximumByteDivisor: 3)
+        let cache = try Self.createCache(overwritesOldMessages: true, maximumByteDivisor: 3)
         for message in Self.lorumIpsumMessages {
             try cache.append(message: message)
         }
@@ -180,7 +180,7 @@ final class CacheAdvanceTests: XCTestCase {
     }
 
     func test_append_dropsLastMessageIfCacheDoesNotRollAndLastMessageDoesNotFit() throws {
-        let cache = try createCache(overwritesOldMessages: false)
+        let cache = try Self.createCache(overwritesOldMessages: false)
         for message in Self.lorumIpsumMessages {
             try cache.append(message: message)
         }
@@ -194,7 +194,7 @@ final class CacheAdvanceTests: XCTestCase {
     }
 
     func test_append_dropsOldestMessageIfCacheRollsAndLastMessageDoesNotFitAndIsShorterThanOldestMessage() throws {
-        let cache = try createCache(overwritesOldMessages: true)
+        let cache = try Self.createCache(overwritesOldMessages: true)
         for message in Self.lorumIpsumMessages {
             try cache.append(message: message)
         }
@@ -208,7 +208,7 @@ final class CacheAdvanceTests: XCTestCase {
     }
 
     func test_append_dropsFirstTwoMessagesIfCacheRollsAndLastMessageDoesNotFitAndIsLargerThanOldestMessage() throws {
-        let cache = try createCache(overwritesOldMessages: true)
+        let cache = try Self.createCache(overwritesOldMessages: true)
         for message in Self.lorumIpsumMessages {
             try cache.append(message: message)
         }
@@ -223,7 +223,7 @@ final class CacheAdvanceTests: XCTestCase {
 
     func test_append_dropsOldMessagesAsNecessary() throws {
         for maximumByteDivisor in stride(from: 1, to: 20, by: 0.1) {
-            let cache = try createCache(overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor)
+            let cache = try Self.createCache(overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor)
             for message in Self.lorumIpsumMessages {
                 try cache.append(message: message)
             }
@@ -234,27 +234,27 @@ final class CacheAdvanceTests: XCTestCase {
     }
 
     func test_append_canWriteMessagesToCacheCreatedByADifferentCache() throws {
-        let cache = try createCache(overwritesOldMessages: false)
+        let cache = try Self.createCache(overwritesOldMessages: false)
         for message in Self.lorumIpsumMessages.dropLast() {
             try cache.append(message: message)
         }
 
         let cachedMessages = try cache.messages()
-        let secondCache = try createCache(overwritesOldMessages: false, zeroOutExistingFile: false)
+        let secondCache = try Self.createCache(overwritesOldMessages: false, zeroOutExistingFile: false)
         try secondCache.append(message: Self.lorumIpsumMessages.last!)
         XCTAssertEqual(cachedMessages + [Self.lorumIpsumMessages.last!], try secondCache.messages())
     }
 
     func test_append_canWriteMessagesToCacheCreatedByADifferentOverridingCache() throws {
         for maximumByteDivisor in stride(from: 1, to: 10, by: 0.5) {
-            let cache = try createCache(overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor)
+            let cache = try Self.createCache(overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor)
             for message in Self.lorumIpsumMessages.dropLast() {
                 try cache.append(message: message)
             }
 
             let cachedMessages = try cache.messages()
 
-            let secondCache = try createCache(overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor)
+            let secondCache = try Self.createCache(overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor)
             try secondCache.append(message: Self.lorumIpsumMessages.last!)
             let secondCacheMessages = try secondCache.messages()
 
@@ -264,7 +264,7 @@ final class CacheAdvanceTests: XCTestCase {
 
     func test_append_canWriteMessagesAfterRetrievingMessages() throws {
         for maximumByteDivisor in stride(from: 1, to: 10, by: 0.5) {
-            let cache = try createCache(overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor)
+            let cache = try Self.createCache(overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor)
             for message in Self.lorumIpsumMessages.dropLast() {
                 try cache.append(message: message)
             }
@@ -278,10 +278,10 @@ final class CacheAdvanceTests: XCTestCase {
     }
 
     func test_append_throwsFileNotWritableWhenMaximumBytesDoesNotMatch() throws {
-        let originalCache = try createCache(overwritesOldMessages: false)
+        let originalCache = try Self.createCache(overwritesOldMessages: false)
         XCTAssertTrue(try originalCache.isWritable())
 
-        let sut = try createCache(
+        let sut = try Self.createCache(
             sizedToFit: Self.lorumIpsumMessages.dropLast(),
             overwritesOldMessages: false,
             zeroOutExistingFile: false)
@@ -291,95 +291,95 @@ final class CacheAdvanceTests: XCTestCase {
     }
 
     func test_append_throwsFileNotWritableWhenOverwritesOldMessagesDoesNotMatch() throws {
-        let originalCache = try createCache(overwritesOldMessages: false)
+        let originalCache = try Self.createCache(overwritesOldMessages: false)
         XCTAssertTrue(try originalCache.isWritable())
 
-        let sut = try createCache(overwritesOldMessages: true, zeroOutExistingFile: false)
+        let sut = try Self.createCache(overwritesOldMessages: true, zeroOutExistingFile: false)
         XCTAssertThrowsError(try sut.append(message: Self.lorumIpsumMessages.last!)) {
             XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.fileNotWritable)
         }
     }
 
     func test_messages_canReadMessagesWrittenByADifferentCache() throws {
-        let cache = try createCache(overwritesOldMessages: false)
+        let cache = try Self.createCache(overwritesOldMessages: false)
         for message in Self.lorumIpsumMessages {
             try cache.append(message: message)
         }
 
-        let secondCache = try createCache(overwritesOldMessages: false, zeroOutExistingFile: false)
+        let secondCache = try Self.createCache(overwritesOldMessages: false, zeroOutExistingFile: false)
         XCTAssertEqual(try cache.messages(), try secondCache.messages())
     }
 
     func test_messages_canReadMessagesWrittenByADifferentFullCache() throws {
-        let cache = try createCache(overwritesOldMessages: false, maximumByteSubtractor: 1)
+        let cache = try Self.createCache(overwritesOldMessages: false, maximumByteSubtractor: 1)
         for message in Self.lorumIpsumMessages.dropLast() {
             try cache.append(message: message)
         }
         XCTAssertThrowsError(try cache.append(message: Self.lorumIpsumMessages.last!))
 
-        let secondCache = try createCache(overwritesOldMessages: false, maximumByteSubtractor: 1, zeroOutExistingFile: false)
+        let secondCache = try Self.createCache(overwritesOldMessages: false, maximumByteSubtractor: 1, zeroOutExistingFile: false)
         XCTAssertEqual(try cache.messages(), try secondCache.messages())
     }
 
     func test_messages_canReadMessagesWrittenByADifferentOverwritingCache() throws {
         for maximumByteDivisor in stride(from: 1, to: 10, by: 0.5) {
-            let cache = try createCache(overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor)
+            let cache = try Self.createCache(overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor)
             for message in Self.lorumIpsumMessages {
                 try cache.append(message: message)
             }
 
-            let secondCache = try createCache(overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor, zeroOutExistingFile: false)
+            let secondCache = try Self.createCache(overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor, zeroOutExistingFile: false)
             XCTAssertEqual(try cache.messages(), try secondCache.messages())
         }
     }
 
     func test_messages_cacheThatDoesNotOverwrite_canReadMessagesWrittenByAnOverwritingCache() throws {
-        let cache = try createCache(overwritesOldMessages: false)
+        let cache = try Self.createCache(overwritesOldMessages: false)
         for message in Self.lorumIpsumMessages {
             try cache.append(message: message)
         }
 
-        let secondCache = try createCache(overwritesOldMessages: true, zeroOutExistingFile: false)
+        let secondCache = try Self.createCache(overwritesOldMessages: true, zeroOutExistingFile: false)
         XCTAssertEqual(try cache.messages(), try secondCache.messages())
     }
 
     func test_messages_cacheThatOverwrites_canReadMessagesWrittenByAnOverwritingCacheWithDifferentMaximumBytes() throws {
         for maximumByteDivisor in stride(from: 1, to: 10, by: 0.5) {
-            let cache = try createCache(overwritesOldMessages: true)
+            let cache = try Self.createCache(overwritesOldMessages: true)
             for message in Self.lorumIpsumMessages {
                 try cache.append(message: message)
             }
 
-            let secondCache = try createCache(overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor, zeroOutExistingFile: false)
+            let secondCache = try Self.createCache(overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor, zeroOutExistingFile: false)
             XCTAssertEqual(try cache.messages(), try secondCache.messages())
         }
     }
 
     func test_messages_cacheThatOverwrites_canReadMessagesWrittenByANonOverwritingCache() throws {
         for maximumByteDivisor in stride(from: 1, to: 10, by: 0.5) {
-            let cache = try createCache(overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor)
+            let cache = try Self.createCache(overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor)
             for message in Self.lorumIpsumMessages {
                 try cache.append(message: message)
             }
 
-            let secondCache = try createCache(overwritesOldMessages: false, zeroOutExistingFile: false)
+            let secondCache = try Self.createCache(overwritesOldMessages: false, zeroOutExistingFile: false)
             XCTAssertEqual(try cache.messages(), try secondCache.messages())
         }
     }
 
     func test_messages_cacheThatDoesNotOverwrites_canReadMessagesWrittenByAnOverwritingCacheWithDifferentMaximumBytes() throws {
         for maximumByteDivisor in stride(from: 1, to: 10, by: 0.5) {
-            let cache = try createCache(overwritesOldMessages: false)
+            let cache = try Self.createCache(overwritesOldMessages: false)
             for message in Self.lorumIpsumMessages {
                 try cache.append(message: message)
             }
 
-            let secondCache = try createCache(overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor, zeroOutExistingFile: false)
+            let secondCache = try Self.createCache(overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor, zeroOutExistingFile: false)
             XCTAssertEqual(try cache.messages(), try secondCache.messages())
         }
     }
 
-    private static let lorumIpsumMessages: [TestableMessage] = [
+    static let lorumIpsumMessages: [TestableMessage] = [
         "Lorem ipsum dolor sit amet,",
         "consectetur adipiscing elit.",
         "Etiam sagittis neque massa,",
@@ -585,17 +585,7 @@ final class CacheAdvanceTests: XCTestCase {
         "at tempus arcu sagittis quis.",
     ]
 
-    private func requiredByteCount<T: Codable>(for messages: [T]) throws -> UInt64 {
-        let encoder = JSONEncoder()
-        return try FileHeader.expectedEndOfHeaderInFile
-            + messages.reduce(0) { allocatedSize, message in
-                let encodableMessage = EncodableMessage(message: message, encoder: encoder)
-                let data = try encodableMessage.encodedData()
-                return allocatedSize + UInt64(data.count)
-        }
-    }
-
-    private func createHeaderHandle(
+    static func createHeaderHandle(
         sizedToFit messages: [TestableMessage] = CacheAdvanceTests.lorumIpsumMessages,
         overwritesOldMessages: Bool,
         maximumByteDivisor: Double = 1,
@@ -615,7 +605,8 @@ final class CacheAdvanceTests: XCTestCase {
             version: version)
     }
 
-    private func createCache(
+    static func createCache(
+        at fileURL: URL = testFileLocation,
         sizedToFit messages: [TestableMessage] = CacheAdvanceTests.lorumIpsumMessages,
         overwritesOldMessages: Bool,
         maximumByteDivisor: Double = 1,
@@ -625,13 +616,25 @@ final class CacheAdvanceTests: XCTestCase {
         -> CacheAdvance<TestableMessage>
     {
         if zeroOutExistingFile {
-            FileManager.default.createFile(atPath: testFileLocation.path, contents: nil, attributes: nil)
+            FileManager.default.createFile(atPath: fileURL.path, contents: nil, attributes: nil)
         }
         return try CacheAdvance<TestableMessage>(
-            fileURL: testFileLocation,
+            fileURL: fileURL,
             maximumBytes: Bytes(Double(try requiredByteCount(for: messages)) / maximumByteDivisor) - maximumByteSubtractor,
             shouldOverwriteOldMessages: overwritesOldMessages)
     }
+
+    private static func requiredByteCount<T: Codable>(for messages: [T]) throws -> UInt64 {
+        let encoder = JSONEncoder()
+        return try FileHeader.expectedEndOfHeaderInFile
+            + messages.reduce(0) { allocatedSize, message in
+                let encodableMessage = EncodableMessage(message: message, encoder: encoder)
+                let data = try encodableMessage.encodedData()
+                return allocatedSize + UInt64(data.count)
+        }
+    }
+
+    private static let testFileLocation = FileManager.default.temporaryDirectory.appendingPathComponent("CacheAdvanceTests")
 
     private func expectedMessagesInOverwritingCache(
         givenOriginal messages: [TestableMessage],
@@ -640,6 +643,4 @@ final class CacheAdvanceTests: XCTestCase {
     {
         Array(messages.dropFirst(messages.count - newMessageCount))
     }
-
-    private let testFileLocation = FileManager.default.temporaryDirectory.appendingPathComponent("CacheAdvanceTests")
 }

--- a/Tests/CacheAdvanceTests/CacheReaderTests.swift
+++ b/Tests/CacheAdvanceTests/CacheReaderTests.swift
@@ -1,0 +1,83 @@
+//
+//  Created by Dan Federman on 11/9/19.
+//  Copyright © 2019 Dan Federman.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS"BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import XCTest
+
+@testable import CacheAdvance
+
+final class CacheReaderTests: XCTestCase {
+
+    // MARK: Behavior Tests
+
+    func test_messages_canReadMessagesWrittenByADifferentCache() throws {
+        let cache = try CacheAdvanceTests.createCache(at: Self.testFileLocation, overwritesOldMessages: false)
+        for message in CacheAdvanceTests.lorumIpsumMessages {
+            try cache.append(message: message)
+        }
+
+        let reader = try CacheReader(fileURL: Self.testFileLocation)
+        XCTAssertEqual(try cache.messages(), try reader.messages())
+    }
+
+    func test_messages_canReadMessagesWrittenByADifferentFullCache() throws {
+        let cache = try CacheAdvanceTests.createCache(at: Self.testFileLocation, overwritesOldMessages: false, maximumByteSubtractor: 1)
+        for message in CacheAdvanceTests.lorumIpsumMessages.dropLast() {
+            try cache.append(message: message)
+        }
+        XCTAssertThrowsError(try cache.append(message: CacheAdvanceTests.lorumIpsumMessages.last!))
+
+        let reader = try CacheReader(fileURL: Self.testFileLocation)
+        XCTAssertEqual(try cache.messages(), try reader.messages())
+    }
+
+    func test_messages_canReadMessagesWrittenByADifferentOverwritingCache() throws {
+        for maximumByteDivisor in stride(from: 1, to: 10, by: 0.5) {
+            let cache = try CacheAdvanceTests.createCache(at: Self.testFileLocation, overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor)
+            for message in CacheAdvanceTests.lorumIpsumMessages {
+                try cache.append(message: message)
+            }
+
+            let reader = try CacheReader(fileURL: Self.testFileLocation)
+            XCTAssertEqual(try cache.messages(), try reader.messages())
+        }
+    }
+
+    func test_messages_cacheThatDoesNotOverwrite_canReadMessagesWrittenByAnOverwritingCache() throws {
+        let cache = try CacheAdvanceTests.createCache(at: Self.testFileLocation, overwritesOldMessages: false)
+        for message in CacheAdvanceTests.lorumIpsumMessages {
+            try cache.append(message: message)
+        }
+
+        let reader = try CacheReader(fileURL: Self.testFileLocation)
+        XCTAssertEqual(try cache.messages(), try reader.messages())
+    }
+
+    func test_messages_cacheThatOverwrites_canReadMessagesWrittenByANonOverwritingCache() throws {
+        for maximumByteDivisor in stride(from: 1, to: 10, by: 0.5) {
+            let cache = try CacheAdvanceTests.createCache(at: Self.testFileLocation, overwritesOldMessages: true, maximumByteDivisor: maximumByteDivisor)
+            for message in CacheAdvanceTests.lorumIpsumMessages {
+                try cache.append(message: message)
+            }
+
+            let reader = try CacheReader(fileURL: Self.testFileLocation)
+            XCTAssertEqual(try cache.messages(), try reader.messages())
+        }
+    }
+
+    private static let testFileLocation = FileManager.default.temporaryDirectory.appendingPathComponent("CacheReaderTests")
+}


### PR DESCRIPTION
Built on top of #37. In this PR I expose the `CacheReader` publicly, in order to enable clients to open caches that were previously written to in an explicitly read-only mode.

I'm very much open to API and naming feedback.

I'm also open to better ways to handle the fact that the `CacheReader` now has the ability to read from a `CacheHeaderHandle`, but that it doesn't need to if the `CacheAdvance` has already set up the `CacheReader`. There's some weird interplay here that isn't the most obvious, but at a minimum it's all well-tested.