### PR TITLE
Add performance tests to CacheAdvance

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/cocoapods/l/CacheAdvance.svg)](https://cocoapods.org/pods/CacheAdvance)
 [![Platform](https://img.shields.io/cocoapods/p/CacheAdvance.svg)](https://cocoapods.org/pods/CacheAdvance)
 
-A performant cache for logging systems. CacheAdvance persists log events 15x faster while utilizing 40% less memory than SQLite.
+A performant cache for logging systems. CacheAdvance persists log events 30x faster than SQLite.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/cocoapods/l/CacheAdvance.svg)](https://cocoapods.org/pods/CacheAdvance)
 [![Platform](https://img.shields.io/cocoapods/p/CacheAdvance.svg)](https://cocoapods.org/pods/CacheAdvance)
 
-A cache that enables the performant persistence of individual messages to disk.
+A cache that enables the performant persistence of individual messages to disk. CacheAdvance message writes are more than 15x faster than raw SQLite writes.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/cocoapods/l/CacheAdvance.svg)](https://cocoapods.org/pods/CacheAdvance)
 [![Platform](https://img.shields.io/cocoapods/p/CacheAdvance.svg)](https://cocoapods.org/pods/CacheAdvance)
 
-A cache that enables the performant persistence of individual messages to disk. CacheAdvance message writes are more than 15x faster than raw SQLite writes.
+A performant cache for logging systems. CacheAdvance persists log events 15x faster while utilizing 40% less memory than SQLite.
 
 ## Usage
 

--- a/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
+++ b/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
@@ -573,7 +573,6 @@ final class CacheAdvanceTests: XCTestCase {
             version: version)
     }
 
-
     private func createCache(
         sizedToFit messages: [TestableMessage] = LorumIpsum.messages,
         overwritesOldMessages: Bool,
@@ -614,6 +613,4 @@ final class CacheAdvanceTests: XCTestCase {
     }
 
     private let testFileLocation = FileManager.default.temporaryDirectory.appendingPathComponent("CacheAdvanceTests")
-
-
 }

--- a/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
+++ b/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
@@ -420,6 +420,62 @@ final class CacheAdvanceTests: XCTestCase {
         }
     }
 
+    func test_performance_append_fillableCache() throws {
+        measure {
+            guard let sut = try? createCache(overwritesOldMessages: false, zeroOutExistingFile: true) else {
+                XCTFail("Could not create cache")
+                return
+            }
+            for message in LorumIpsum.messages {
+                try? sut.append(message: message)
+            }
+        }
+    }
+
+    func test_performance_messages_fillableCache() throws {
+        guard let sut = try? createCache(overwritesOldMessages: false, zeroOutExistingFile: true) else {
+            XCTFail("Could not create cache")
+            return
+        }
+        for message in LorumIpsum.messages {
+            try? sut.append(message: message)
+        }
+        measure {
+            guard (try? sut.messages()) != nil else {
+                XCTFail("Could not read messages")
+                return
+            }
+        }
+    }
+
+    func test_performance_append_overwritingCache() throws {
+        measure {
+            guard let sut = try? createCache(overwritesOldMessages: true, zeroOutExistingFile: false) else {
+                XCTFail("Could not create cache")
+                return
+            }
+            for message in LorumIpsum.messages {
+                try? sut.append(message: message)
+            }
+        }
+    }
+
+    func test_performance_messages_overwritingCache() throws {
+        guard let sut = try? createCache(overwritesOldMessages: true, zeroOutExistingFile: false) else {
+            XCTFail("Could not create cache")
+            return
+        }
+        for message in LorumIpsum.messages {
+            try? sut.append(message: message)
+        }
+        measure {
+            guard (try? sut.messages()) != nil else {
+                XCTFail("Could not read messages")
+                return
+            }
+        }
+    }
+
     // MARK: Private
 
     private func requiredByteCount<T: Codable>(for messages: [T]) throws -> UInt64 {

--- a/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
+++ b/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
@@ -474,6 +474,9 @@ final class CacheAdvanceTests: XCTestCase {
 
     func test_performance_createCacheAndAppendSingleMessage() throws {
         measure {
+            // Delete any existing cache.
+            FileManager.default.createFile(atPath: testFileLocation.path, contents: nil, attributes: nil)
+
             guard let sut = try? createCache(maximumByes: 100, overwritesOldMessages: true, zeroOutExistingFile: false) else {
                 XCTFail("Could not create cache")
                 return

--- a/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
+++ b/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
@@ -22,15 +22,6 @@ import XCTest
 
 final class CacheAdvanceTests: XCTestCase {
 
-    // MARK: XCTestCase
-
-    override func setUp() {
-        super.setUp()
-
-        // Clear out any existing cache.
-        FileManager.default.createFile(atPath: testFileLocation.path, contents: nil, attributes: nil)
-    }
-
     // MARK: Behavior Tests
 
     func test_isEmpty_returnsTrueWhenCacheIsEmpty() throws {

--- a/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
+++ b/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
@@ -489,8 +489,9 @@ final class CacheAdvanceTests: XCTestCase {
             XCTFail("Could not create cache")
             return
         }
+        // Force the cache to set up before we start writing messages.
+        _ = try sut.isWritable()
         measure {
-            // Append all messages, filling up the cache.
             for message in LorumIpsum.messages {
                 try? sut.append(message: message)
             }
@@ -498,12 +499,9 @@ final class CacheAdvanceTests: XCTestCase {
     }
 
     func test_performance_messages_fillableCache() throws {
-        guard let sut = try? createCache(overwritesOldMessages: false, zeroOutExistingFile: true) else {
-            XCTFail("Could not create cache")
-            return
-        }
+        let sut = try createCache(overwritesOldMessages: false, zeroOutExistingFile: true)
         for message in LorumIpsum.messages {
-            try? sut.append(message: message)
+            try sut.append(message: message)
         }
         measure {
             guard (try? sut.messages()) != nil else {
@@ -515,13 +513,10 @@ final class CacheAdvanceTests: XCTestCase {
 
     func test_performance_append_overwritingCache() throws {
         let maximumBytes = Bytes(Double(try requiredByteCount(for: LorumIpsum.messages)))
-        guard let sut = try? createCache(maximumByes: maximumBytes, overwritesOldMessages: true, zeroOutExistingFile: true) else {
-            XCTFail("Could not create cache")
-            return
-        }
+        let sut = try createCache(maximumByes: maximumBytes, overwritesOldMessages: true, zeroOutExistingFile: true)
         // Fill the cache before the test starts.
         for message in LorumIpsum.messages {
-            try? sut.append(message: message)
+            try sut.append(message: message)
         }
         measure {
             for message in LorumIpsum.messages {
@@ -531,12 +526,9 @@ final class CacheAdvanceTests: XCTestCase {
     }
 
     func test_performance_messages_overwritingCache() throws {
-        guard let sut = try? createCache(overwritesOldMessages: true, zeroOutExistingFile: false) else {
-            XCTFail("Could not create cache")
-            return
-        }
+        let sut = try createCache(overwritesOldMessages: true, zeroOutExistingFile: false)
         for message in LorumIpsum.messages {
-            try? sut.append(message: message)
+            try sut.append(message: message)
         }
         measure {
             guard (try? sut.messages()) != nil else {

--- a/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
+++ b/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
@@ -471,7 +471,7 @@ final class CacheAdvanceTests: XCTestCase {
             return
         }
         measure {
-            // Append all messages, filling up the cahce.
+            // Append all messages, filling up the cache.
             for message in LorumIpsum.messages {
                 try? sut.append(message: message)
             }
@@ -489,7 +489,7 @@ final class CacheAdvanceTests: XCTestCase {
             return
         }
         measure(metrics: [XCTMemoryMetric()]) {
-            // Append all messages, filling up the cahce.
+            // Append all messages, filling up the cache.
             for message in LorumIpsum.messages {
                 try? sut.append(message: message)
             }

--- a/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
+++ b/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
@@ -498,19 +498,6 @@ final class CacheAdvanceTests: XCTestCase {
         }
     }
 
-    func test_performance_messages_fillableCache() throws {
-        let sut = try createCache(overwritesOldMessages: false, zeroOutExistingFile: true)
-        for message in LorumIpsum.messages {
-            try sut.append(message: message)
-        }
-        measure {
-            guard (try? sut.messages()) != nil else {
-                XCTFail("Could not read messages")
-                return
-            }
-        }
-    }
-
     func test_performance_append_overwritingCache() throws {
         let maximumBytes = Bytes(Double(try requiredByteCount(for: LorumIpsum.messages)))
         let sut = try createCache(maximumByes: maximumBytes, overwritesOldMessages: true, zeroOutExistingFile: true)
@@ -525,9 +512,22 @@ final class CacheAdvanceTests: XCTestCase {
         }
     }
 
-    func test_performance_messages_overwritingCache() throws {
-        let sut = try createCache(overwritesOldMessages: true, zeroOutExistingFile: false)
+    func test_performance_messages_fillableCache() throws {
+        let sut = try createCache(overwritesOldMessages: false, zeroOutExistingFile: true)
         for message in LorumIpsum.messages {
+            try sut.append(message: message)
+        }
+        measure {
+            guard (try? sut.messages()) != nil else {
+                XCTFail("Could not read messages")
+                return
+            }
+        }
+    }
+
+    func test_performance_messages_overwritingCache() throws {
+        let sut = try createCache(overwritesOldMessages: true, zeroOutExistingFile: true)
+        for message in LorumIpsum.messages + LorumIpsum.messages {
             try sut.append(message: message)
         }
         measure {

--- a/Tests/CacheAdvanceTests/FlushableCachePerformanceComparisonTests.swift
+++ b/Tests/CacheAdvanceTests/FlushableCachePerformanceComparisonTests.swift
@@ -211,7 +211,6 @@ final class FlushableCachePerformanceComparisonTests: XCTestCase {
     // MARK: Private
 
     private let testFileLocation = FileManager.default.temporaryDirectory.appendingPathComponent("SQLiteTests")
-
 }
 
 /// A simple in-memory cache that can be flushed to disk.

--- a/Tests/CacheAdvanceTests/FlushableCachePerformanceComparisonTests.swift
+++ b/Tests/CacheAdvanceTests/FlushableCachePerformanceComparisonTests.swift
@@ -1,0 +1,139 @@
+//
+//  Created by Dan Federman on 4/26/20.
+//  Copyright © 2020 Dan Federman.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS"BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+final class FlushableCachePerformanceComparisonTests: XCTestCase {
+
+    // MARK: XCTestCase
+
+    override func setUp() {
+        super.setUp()
+
+        // Delete the existing cache.
+        try? Data().write(to: testFileLocation)
+    }
+
+    // MARK: Performance Tests
+
+    func test_performance_json_createDatabaseAndAppendSingleMessage() throws {
+        measure {
+            let cache = FlushableCache<TestableMessage>(location: testFileLocation)
+            try? cache.appendMessage("test message")
+        }
+    }
+
+    func test_performance_json_appendAndFlushOnEachMessage() throws {
+        measure {
+            // Delete the existing cache.
+            try? Data().write(to: testFileLocation)
+
+            let cache = FlushableCache<TestableMessage>(location: testFileLocation)
+            for message in LorumIpsum.messages {
+                try? cache.appendMessage(message)
+                try? cache.flushMessages()
+            }
+        }
+    }
+
+    func test_performance_json_appendAndFlushEvery50Messages() throws {
+        measure {
+            // Delete the existing cache.
+            try? Data().write(to: testFileLocation)
+
+            let cache = FlushableCache<TestableMessage>(location: testFileLocation)
+            for (index, message) in LorumIpsum.messages.enumerated() {
+                try? cache.appendMessage(message)
+                if index % 50 == 0 {
+                    try? cache.flushMessages()
+                }
+            }
+        }
+    }
+
+    func test_performance_json_messages() throws {
+        let cache = FlushableCache<TestableMessage>(location: testFileLocation)
+        for message in LorumIpsum.messages {
+            try cache.appendMessage(message)
+        }
+        try cache.flushMessages()
+        measure {
+            let freshCache = FlushableCache<TestableMessage>(location: testFileLocation)
+            _ = try? freshCache.messages()
+        }
+    }
+
+    // MARK: Behavior Tests
+
+    func test_readMessages_canReadInsertedMessages() throws {
+        let cache = FlushableCache<TestableMessage>(location: testFileLocation)
+        for message in LorumIpsum.messages {
+            try cache.appendMessage(message)
+        }
+
+        XCTAssertEqual(try cache.messages(), LorumIpsum.messages)
+    }
+
+    // MARK: Private
+
+    private let testFileLocation = FileManager.default.temporaryDirectory.appendingPathComponent("SQLiteTests")
+
+}
+
+/// A simple in-memory cache that can be flushed to disk.
+class FlushableCache<T: Codable> {
+
+    // MARK: Initialization
+
+    init(location: URL) {
+        self.location = location
+    }
+
+    // MARK: Internal
+
+    func appendMessage(_ message: T) throws {
+        _messages = try messages() + [message]
+    }
+
+    func messages() throws -> [T] {
+        if let _messages = _messages {
+            return _messages
+        } else {
+            let persistedData = try Data(contentsOf: location)
+            guard !persistedData.isEmpty else {
+                _messages = []
+                return []
+            }
+            let persistedMessages = try decoder.decode([T].self, from: persistedData)
+            _messages = persistedMessages
+            return persistedMessages
+        }
+    }
+
+    func flushMessages() throws {
+        try encoder.encode(try messages()).write(to: location)
+    }
+
+    // MARK: Private
+
+    private var _messages: [T]?
+
+    private let location: URL
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+}

--- a/Tests/CacheAdvanceTests/FlushableCachePerformanceComparisonTests.swift
+++ b/Tests/CacheAdvanceTests/FlushableCachePerformanceComparisonTests.swift
@@ -28,6 +28,17 @@ final class FlushableCachePerformanceComparisonTests: XCTestCase {
         try? Data().write(to: testFileLocation)
     }
 
+    // MARK: Behavior Tests
+
+    func test_readMessages_canReadInsertedMessages() throws {
+        let cache = FlushableCache<TestableMessage>(location: testFileLocation)
+        for message in LorumIpsum.messages {
+            try cache.appendMessage(message)
+        }
+
+        XCTAssertEqual(try cache.messages(), LorumIpsum.messages)
+    }
+
     // MARK: Performance Tests
 
     func test_performance_json_createDatabaseAndAppendSingleMessage() throws {
@@ -75,17 +86,6 @@ final class FlushableCachePerformanceComparisonTests: XCTestCase {
             let freshCache = FlushableCache<TestableMessage>(location: testFileLocation)
             _ = try? freshCache.messages()
         }
-    }
-
-    // MARK: Behavior Tests
-
-    func test_readMessages_canReadInsertedMessages() throws {
-        let cache = FlushableCache<TestableMessage>(location: testFileLocation)
-        for message in LorumIpsum.messages {
-            try cache.appendMessage(message)
-        }
-
-        XCTAssertEqual(try cache.messages(), LorumIpsum.messages)
     }
 
     // MARK: Private

--- a/Tests/CacheAdvanceTests/LorumIpsumMessages.swift
+++ b/Tests/CacheAdvanceTests/LorumIpsumMessages.swift
@@ -1,3 +1,4 @@
+//
 //  Created by Dan Federman on 4/23/20.
 //  Copyright © 2020 Dan Federman.
 //

--- a/Tests/CacheAdvanceTests/SQLitePerformanceComparisonTests.swift
+++ b/Tests/CacheAdvanceTests/SQLitePerformanceComparisonTests.swift
@@ -158,7 +158,6 @@ final class SQLitePerformanceComparisonTests: XCTestCase {
     // MARK: Private
 
     private let testFileLocation = FileManager.default.temporaryDirectory.appendingPathComponent("SQLiteTests")
-
 }
 
 class SQLiteCache<T: Codable> {

--- a/Tests/CacheAdvanceTests/SQLitePerformanceComparisonTests.swift
+++ b/Tests/CacheAdvanceTests/SQLitePerformanceComparisonTests.swift
@@ -138,7 +138,7 @@ final class SQLitePerformanceComparisonTests: XCTestCase {
             cache.appendMessage(message)
         }
         measure {
-            let _ = cache.messages()
+            _ = cache.messages()
         }
     }
 
@@ -151,7 +151,7 @@ final class SQLitePerformanceComparisonTests: XCTestCase {
             cache.appendMessage(message)
         }
         measure {
-            let _ = cache.messages()
+            _ = cache.messages()
         }
     }
 
@@ -165,9 +165,10 @@ class SQLiteCache<T: Codable> {
 
     // MARK: Initialization
 
-    init(location: URL,
-         maxMessageCount: Int32,
-         shouldOverwriteMessages: Bool)
+    init(
+        location: URL,
+        maxMessageCount: Int32,
+        shouldOverwriteMessages: Bool)
     {
         self.location = location
         self.maxMessageCount = maxMessageCount

--- a/Tests/CacheAdvanceTests/SQLitePerformanceComparisonTests.swift
+++ b/Tests/CacheAdvanceTests/SQLitePerformanceComparisonTests.swift
@@ -32,7 +32,14 @@ final class SQLitePerformanceComparisonTests: XCTestCase {
 
     // MARK: Performance Tests
 
-    func test_performance_append_sqlite() {
+    func test_performance_createDatabaseAndAppendSingleMessage() {
+        measure {
+            createDatabase()
+            insertMessage("test message")
+        }
+    }
+
+    func test_performance_sqlite_append() {
         createDatabase()
         measure {
             for message in LorumIpsum.messages {
@@ -41,46 +48,19 @@ final class SQLitePerformanceComparisonTests: XCTestCase {
         }
     }
 
-    func test_memory_append_sqlite() {
-        guard #available(iOS 13.0, tvOS 13.0, macOS 10.15, *) else {
-            return
-        }
-
-        createDatabase()
-        measure(metrics: [XCTMemoryMetric()]) {
-            for message in LorumIpsum.messages {
-                insertMessage(message)
-            }
-        }
-    }
-
-    func test_performance_messages_sqlite() {
+    func test_performance_sqlite_messages() {
         createDatabase()
         for message in LorumIpsum.messages {
             insertMessage(message)
         }
         measure {
-            let _ = readMessages()
-        }
-    }
-
-    func test_memory_messages_sqlite() {
-        guard #available(iOS 13.0, tvOS 13.0, macOS 10.15, *) else {
-            return
-        }
-
-        createDatabase()
-        for message in LorumIpsum.messages {
-            insertMessage(message)
-        }
-        measure(metrics: [XCTMemoryMetric()]) {
             let _ = readMessages()
         }
     }
 
     // MARK: Behavior Tests
 
-    func test_readMessages_canReadInsertedMessages() {
+    func test_readMessages_sqlite_canReadInsertedMessages() {
         createDatabase()
         for message in LorumIpsum.messages {
             insertMessage(message)

--- a/Tests/CacheAdvanceTests/SQLitePerformanceComparisonTests.swift
+++ b/Tests/CacheAdvanceTests/SQLitePerformanceComparisonTests.swift
@@ -1,3 +1,4 @@
+//
 //  Created by Dan Federman on 4/23/20.
 //  Copyright © 2020 Dan Federman.
 //

--- a/Tests/CacheAdvanceTests/SQLitePerformanceComparisonTests.swift
+++ b/Tests/CacheAdvanceTests/SQLitePerformanceComparisonTests.swift
@@ -24,59 +24,156 @@ final class SQLitePerformanceComparisonTests: XCTestCase {
 
     // MARK: XCTestCase
 
-    override func tearDown() {
-        sqlite3_close(db)
+    override func setUp() {
+        super.setUp()
 
-        super.tearDown()
+        // Delete the existing cache.
+        try? FileManager.default.removeItem(at: testFileLocation)
+    }
+
+    // MARK: Behavior Tests
+
+    func test_append_sqlite_fillableCache_canMaintainMaxCount() {
+        let cache = SQLiteCache<TestableMessage>(
+            location: testFileLocation,
+            maxMessageCount: Int32(LorumIpsum.messages.count),
+            shouldOverwriteMessages: false)
+        for message in LorumIpsum.messages + LorumIpsum.messages {
+            cache.appendMessage(message)
+        }
+
+        XCTAssertEqual(cache.messages().count, LorumIpsum.messages.count)
+    }
+
+    func test_messages_sqlite_fillableCache_canReadInsertedMessages() {
+        let cache = SQLiteCache<TestableMessage>(
+            location: testFileLocation,
+            maxMessageCount: Int32(LorumIpsum.messages.count),
+            shouldOverwriteMessages: true)
+        for message in LorumIpsum.messages {
+            cache.appendMessage(message)
+        }
+
+        XCTAssertEqual(cache.messages(), LorumIpsum.messages)
+    }
+
+    func test_append_sqlite_overwritingCache_canMaintainMaxCount() {
+        let cache = SQLiteCache<TestableMessage>(
+            location: testFileLocation,
+            maxMessageCount: Int32(LorumIpsum.messages.count),
+            shouldOverwriteMessages: true)
+        for message in LorumIpsum.messages + LorumIpsum.messages {
+            cache.appendMessage(message)
+        }
+
+        XCTAssertEqual(cache.messages().count, LorumIpsum.messages.count)
+    }
+
+    func test_messages_sqlite_overwritingCache_canReadInsertedMessages() {
+        let cache = SQLiteCache<TestableMessage>(
+            location: testFileLocation,
+            maxMessageCount: Int32(LorumIpsum.messages.count),
+            shouldOverwriteMessages: true)
+        for message in LorumIpsum.messages {
+            cache.appendMessage(message)
+        }
+
+        XCTAssertEqual(cache.messages(), LorumIpsum.messages)
     }
 
     // MARK: Performance Tests
 
     func test_performance_createDatabaseAndAppendSingleMessage() {
         measure {
-            createDatabase()
-            insertMessage("test message")
+            // Delete any existing database.
+            try? FileManager.default.removeItem(at: testFileLocation)
+
+            let cache = SQLiteCache<TestableMessage>(
+                location: testFileLocation,
+                maxMessageCount: Int32(LorumIpsum.messages.count),
+                shouldOverwriteMessages: false)
+
+            cache.appendMessage("test message")
         }
     }
 
-    func test_performance_sqlite_append() {
-        createDatabase()
+    func test_performance_sqlite_append_fillableCache() {
+         // Create a cache that won't run out of room over multiple test runs.
+        let cache = SQLiteCache<TestableMessage>(
+            location: testFileLocation,
+            maxMessageCount: Int32(LorumIpsum.messages.count * 10),
+            shouldOverwriteMessages: false)
+        cache.createDatabaseIfNecessay()
+
         measure {
             for message in LorumIpsum.messages {
-                insertMessage(message)
+                cache.appendMessage(message)
+            }
+        }
+    }
+
+    func test_performance_sqlite_append_overwritingCache() {
+        let cache = SQLiteCache<TestableMessage>(
+            location: testFileLocation,
+            maxMessageCount: Int32(LorumIpsum.messages.count),
+            shouldOverwriteMessages: true)
+
+        // Fill the cache before the test starts.
+        for message in LorumIpsum.messages {
+            cache.appendMessage(message)
+        }
+        measure {
+            for message in LorumIpsum.messages {
+                cache.appendMessage(message)
             }
         }
     }
 
     func test_performance_sqlite_messages() {
-        createDatabase()
+        let cache = SQLiteCache<TestableMessage>(
+            location: testFileLocation,
+            maxMessageCount: Int32(LorumIpsum.messages.count),
+            shouldOverwriteMessages: false)
         for message in LorumIpsum.messages {
-            insertMessage(message)
+            cache.appendMessage(message)
         }
         measure {
-            let _ = readMessages()
+            let _ = cache.messages()
         }
-    }
-
-    // MARK: Behavior Tests
-
-    func test_readMessages_sqlite_canReadInsertedMessages() {
-        createDatabase()
-        for message in LorumIpsum.messages {
-            insertMessage(message)
-        }
-
-        XCTAssertEqual(readMessages(), LorumIpsum.messages)
     }
 
     // MARK: Private
 
-    func createDatabase() {
+    private let testFileLocation = FileManager.default.temporaryDirectory.appendingPathComponent("SQLiteTests")
+
+}
+
+class SQLiteCache<T: Codable> {
+
+    // MARK: Initialization
+
+    init(location: URL,
+         maxMessageCount: Int32,
+         shouldOverwriteMessages: Bool)
+    {
+        self.location = location
+        self.maxMessageCount = maxMessageCount
+        self.shouldOverwriteMessages = shouldOverwriteMessages
+    }
+
+    deinit {
         if let db = db {
             sqlite3_close(db)
         }
-        try? FileManager.default.removeItem(at: testFileLocation)
-        guard sqlite3_open(NSString(string: testFileLocation.path).utf8String, &db) == SQLITE_OK else {
+    }
+
+    // MARK: Internal
+
+    func createDatabaseIfNecessay() {
+        guard db == nil else {
+            return
+        }
+        guard sqlite3_open(NSString(string: location.path).utf8String, &db) == SQLITE_OK else {
             XCTFail("Failed to open database")
             return
         }
@@ -92,11 +189,34 @@ final class SQLitePerformanceComparisonTests: XCTestCase {
         sqlite3_finalize(createTableStatement)
     }
 
-    func insertMessage(_ message: TestableMessage) {
+    func appendMessage(_ message: T) {
+        createDatabaseIfNecessay()
         guard let messageData = try? encoder.encode(message),
             let messageDataPointer = messageData.withUnsafeBytes({ $0.baseAddress }) else {
             XCTFail("Could not encode message")
             return
+        }
+
+        if messageCount() == maxMessageCount {
+            guard shouldOverwriteMessages else {
+                // We do not have room for this message.
+                return
+            }
+            // Delete the first message to make room for this message.
+            let rawDeleteQuery = "DELETE FROM Messages ORDER BY rowid LIMIT 1;"
+            var deleteQuery: OpaquePointer?
+            guard sqlite3_prepare_v2(db, rawDeleteQuery, -1, &deleteQuery, nil) == SQLITE_OK else {
+                XCTFail("Failed to prepare delete")
+                return
+            }
+            defer {
+                sqlite3_finalize(deleteQuery)
+            }
+
+            guard sqlite3_step(deleteQuery) == SQLITE_DONE else {
+                XCTFail("Failed to delete top messages")
+                return
+            }
         }
 
         let insertStatementString = "INSERT INTO Messages(Message) VALUES (?);"
@@ -114,7 +234,8 @@ final class SQLitePerformanceComparisonTests: XCTestCase {
         sqlite3_finalize(insertStatement)
     }
 
-    func readMessages() -> [TestableMessage] {
+    func messages() -> [T] {
+        createDatabaseIfNecessay()
         let rawQuery = "SELECT * FROM Messages;"
         var query: OpaquePointer?
         guard sqlite3_prepare_v2(db, rawQuery, -1, &query, nil) == SQLITE_OK else {
@@ -124,7 +245,7 @@ final class SQLitePerformanceComparisonTests: XCTestCase {
         defer {
             sqlite3_finalize(query)
         }
-        var logs = [TestableMessage]()
+        var logs = [T]()
         while sqlite3_step(query) == SQLITE_ROW {
             guard let messageDataPointer = sqlite3_column_blob(query, 0) else {
                 XCTFail("Failed to retrieve message blob")
@@ -132,7 +253,7 @@ final class SQLitePerformanceComparisonTests: XCTestCase {
             }
             let messageLength = sqlite3_column_bytes(query, 0)
             let messageData = Data(bytes: messageDataPointer, count: Int(messageLength))
-            guard let message = try? decoder.decode(TestableMessage.self, from: messageData) else {
+            guard let message = try? decoder.decode(T.self, from: messageData) else {
                 XCTFail("Failed to decode message")
                 return []
             }
@@ -142,10 +263,32 @@ final class SQLitePerformanceComparisonTests: XCTestCase {
         return logs
     }
 
-    private var db: OpaquePointer?
+    // MARK: Private
 
-    private let testFileLocation = FileManager.default.temporaryDirectory.appendingPathComponent("SQLiteTests")
+    private var db: OpaquePointer?
+    private let location: URL
+    private let maxMessageCount: Int32
+    private let shouldOverwriteMessages: Bool
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
+
+    private func messageCount() -> Int32 {
+        let rawCountQuery = "SELECT COUNT(*) FROM Messages;"
+        var countQuery: OpaquePointer?
+        guard sqlite3_prepare_v2(db, rawCountQuery, -1, &countQuery, nil) == SQLITE_OK else {
+            XCTFail("Failed to prepare read")
+            return Int32.max
+        }
+        defer {
+            sqlite3_finalize(countQuery)
+        }
+
+        guard sqlite3_step(countQuery) == SQLITE_ROW else {
+            XCTFail("Failed to get persisted message count")
+            return Int32.max
+        }
+
+        return sqlite3_column_int(countQuery, 0)
+    }
 
 }

--- a/Tests/CacheAdvanceTests/SQLitePerformanceComparisonTests.swift
+++ b/Tests/CacheAdvanceTests/SQLitePerformanceComparisonTests.swift
@@ -30,25 +30,63 @@ final class SQLitePerformanceComparisonTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: Behavior Tests
+    // MARK: Performance Tests
 
-    func test_performance_append_sqlite() throws {
+    func test_performance_append_sqlite() {
+        createDatabase()
         measure {
-            createDatabase()
             for message in LorumIpsum.messages {
-                insertMessage(message.value)
+                insertMessage(message)
             }
         }
     }
 
-    func test_performance_messages_sqlite() throws {
+    func test_memory_append_sqlite() {
+        guard #available(iOS 13.0, tvOS 13.0, macOS 10.15, *) else {
+            return
+        }
+
+        createDatabase()
+        measure(metrics: [XCTMemoryMetric()]) {
+            for message in LorumIpsum.messages {
+                insertMessage(message)
+            }
+        }
+    }
+
+    func test_performance_messages_sqlite() {
         createDatabase()
         for message in LorumIpsum.messages {
-            insertMessage(message.value)
+            insertMessage(message)
         }
         measure {
             let _ = readMessages()
         }
+    }
+
+    func test_memory_messages_sqlite() {
+        guard #available(iOS 13.0, tvOS 13.0, macOS 10.15, *) else {
+            return
+        }
+
+        createDatabase()
+        for message in LorumIpsum.messages {
+            insertMessage(message)
+        }
+        measure(metrics: [XCTMemoryMetric()]) {
+            let _ = readMessages()
+        }
+    }
+
+    // MARK: Behavior Tests
+
+    func test_readMessages_canReadInsertedMessages() {
+        createDatabase()
+        for message in LorumIpsum.messages {
+            insertMessage(message)
+        }
+
+        XCTAssertEqual(readMessages(), LorumIpsum.messages)
     }
 
     // MARK: Private

--- a/Tests/CacheAdvanceTests/SQLitePerformanceComparisonTests.swift
+++ b/Tests/CacheAdvanceTests/SQLitePerformanceComparisonTests.swift
@@ -129,12 +129,25 @@ final class SQLitePerformanceComparisonTests: XCTestCase {
         }
     }
 
-    func test_performance_sqlite_messages() {
+    func test_performance_sqlite_messages_fillableCache() {
         let cache = SQLiteCache<TestableMessage>(
             location: testFileLocation,
             maxMessageCount: Int32(LorumIpsum.messages.count),
             shouldOverwriteMessages: false)
         for message in LorumIpsum.messages {
+            cache.appendMessage(message)
+        }
+        measure {
+            let _ = cache.messages()
+        }
+    }
+
+    func test_performance_sqlite_messages_overwritingCache() {
+        let cache = SQLiteCache<TestableMessage>(
+            location: testFileLocation,
+            maxMessageCount: Int32(LorumIpsum.messages.count),
+            shouldOverwriteMessages: true)
+        for message in LorumIpsum.messages + LorumIpsum.messages {
             cache.appendMessage(message)
         }
         measure {

--- a/Tests/CacheAdvanceTests/SQLitePerformanceComparisonTests.swift
+++ b/Tests/CacheAdvanceTests/SQLitePerformanceComparisonTests.swift
@@ -1,0 +1,111 @@
+//  Created by Dan Federman on 4/23/20.
+//  Copyright © 2020 Dan Federman.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS"BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SQLite3
+import XCTest
+
+final class SQLitePerformanceComparisonTests: XCTestCase {
+
+    // MARK: XCTestCase
+
+    override func tearDown() {
+        sqlite3_close(db)
+
+        super.tearDown()
+    }
+
+    // MARK: Behavior Tests
+
+    func test_performance_append_sqlite() throws {
+        measure {
+            createDatabase()
+            for message in LorumIpsum.messages {
+                insertMessage(message.value)
+            }
+        }
+    }
+
+    func test_performance_messages_sqlite() throws {
+        createDatabase()
+        for message in LorumIpsum.messages {
+            insertMessage(message.value)
+        }
+        measure {
+            let _ = readMessages()
+        }
+    }
+
+    // MARK: Private
+
+    func createDatabase() {
+        if let db = db {
+            sqlite3_close(db)
+        }
+        try? FileManager.default.removeItem(at: testFileLocation)
+        guard sqlite3_open(NSString(string: testFileLocation.path).utf8String, &db) == SQLITE_OK else {
+            XCTFail("Failed to open database")
+            return
+        }
+        var createTableStatement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, "CREATE TABLE Messages(Message TEXT);", -1, &createTableStatement, nil) == SQLITE_OK else {
+            XCTFail("Failed to prepare database")
+            return
+        }
+        guard sqlite3_step(createTableStatement) == SQLITE_DONE else {
+            XCTFail("Failed to create database")
+            return
+        }
+        sqlite3_finalize(createTableStatement)
+    }
+
+    func insertMessage(_ message: String) {
+        let insertStatementString = "INSERT INTO Messages(Message) VALUES ('\(message)');"
+        var insertStatement: OpaquePointer?
+
+        guard sqlite3_prepare_v2(db, insertStatementString, -1, &insertStatement, nil) == SQLITE_OK else {
+            XCTFail("Failed to prepare message")
+            return
+        }
+        sqlite3_bind_text(insertStatement, 2, NSString(string: message).utf8String, -1, nil)
+        guard sqlite3_step(insertStatement) == SQLITE_DONE else {
+            XCTFail("Failed to insert message")
+            return
+        }
+        sqlite3_finalize(insertStatement)
+    }
+
+    func readMessages() -> [String] {
+        let rawQuery = "SELECT * FROM Messages;"
+        var query: OpaquePointer?
+        guard sqlite3_prepare_v2(db, rawQuery, -1, &query, nil) == SQLITE_OK else {
+            XCTFail("Failed to prepare read")
+            return []
+        }
+        defer {
+            sqlite3_finalize(query)
+        }
+        var logs = [String]()
+        while sqlite3_step(query) == SQLITE_ROW {
+            let log = String(cString: sqlite3_column_text(query, 0))
+            logs.append(log)
+        }
+
+        return logs
+    }
+
+    private var db: OpaquePointer?
+    private let testFileLocation = FileManager.default.temporaryDirectory.appendingPathComponent("SQLiteTests")
+}


### PR DESCRIPTION
This PR should be reviewed using the Files changed view.

This PR introduces performance tests to CacheAdvance, as well as tests that compare CacheAdvance's performance to SQLite. The results are that CacheAdvance is more than 15x faster at appending messages than SQLite. SQLite is expectedly _significantly_ faster at reading messages, but CacheAdvance has always optimized for writing speed over reading speed.

Note that the 15x faster number is a lower bound. I've seen test runs where CacheAdvance performs more than 50x faster than SQLite.