### PR TITLE
CacheAdvance isn't Carthage compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![CI Status](https://travis-ci.com/dfed/CacheAdvance.svg?branch=main)](https://travis-ci.com/dfed/CacheAdvance)
 [![Swift Package Manager compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://github.com/apple/swift-package-manager)
-[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Version](https://img.shields.io/cocoapods/v/CacheAdvance.svg)](https://cocoapods.org/pods/CacheAdvance)
 [![License](https://img.shields.io/cocoapods/l/CacheAdvance.svg)](https://cocoapods.org/pods/CacheAdvance)
 [![Platform](https://img.shields.io/cocoapods/p/CacheAdvance.svg)](https://cocoapods.org/pods/CacheAdvance)


### PR DESCRIPTION
It looks like [Carthage requires an Xcode project to be committed to the project if you want Carthage to build your project from source](https://github.com/Carthage/Carthage#share-your-xcode-schemes). Running `carthage build --no-skip-current` in this repo fails with the following error:

> *** Skipped building CacheAdvance due to the error:
Dependency "CacheAdvance" has no shared framework schemes

As such, I'm removing the badge from the README.