### PR TITLE
Expose encountered header version in incompatibleHeader error

### DIFF
--- a/CacheAdvance.podspec
+++ b/CacheAdvance.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'CacheAdvance'
-  s.version  = '1.1.0'
+  s.version  = '1.2.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A performant cache for logging systems. CacheAdvance persists log events 30x faster than SQLite.'
   s.homepage = 'https://github.com/dfed/CacheAdvance'

--- a/Sources/CacheAdvance/CacheAdvance.swift
+++ b/Sources/CacheAdvance/CacheAdvance.swift
@@ -73,7 +73,7 @@ public final class CacheAdvance<T: Codable> {
     /// - Parameter message: A message to write to disk. Must be smaller than both `maximumBytes - FileHeader.expectedEndOfHeaderInFile` and `MessageSpan.max`.
     public func append(message: T) throws {
         try setUpFileHandlesIfNecessary()
-        try header.openFile()
+        try header.checkFile()
         guard try header.canWriteToFile() else {
             throw CacheAdvanceError.fileNotWritable
         }
@@ -140,7 +140,7 @@ public final class CacheAdvance<T: Codable> {
     /// - Returns: `true` when there are no messages written to the file.
     public func isEmpty() throws -> Bool {
         try setUpFileHandlesIfNecessary()
-        try header.openFile()
+        try header.checkFile()
 
         return header.offsetInFileAtEndOfNewestMessage == FileHeader.expectedEndOfHeaderInFile
     }
@@ -148,7 +148,7 @@ public final class CacheAdvance<T: Codable> {
     /// Fetches all messages from the cache.
     public func messages() throws -> [T] {
         try setUpFileHandlesIfNecessary()
-        try header.openFile()
+        try header.checkFile()
 
         var messages = [T]()
         while let encodedMessage = try reader.nextEncodedMessage() {

--- a/Sources/CacheAdvance/CacheAdvance.swift
+++ b/Sources/CacheAdvance/CacheAdvance.swift
@@ -73,9 +73,7 @@ public final class CacheAdvance<T: Codable> {
     /// - Parameter message: A message to write to disk. Must be smaller than both `maximumBytes - FileHeader.expectedEndOfHeaderInFile` and `MessageSpan.max`.
     public func append(message: T) throws {
         try setUpFileHandlesIfNecessary()
-        guard try header.canOpenFile() else {
-            throw CacheAdvanceError.incompatibleHeader
-        }
+        try header.openFile()
         guard try header.canWriteToFile() else {
             throw CacheAdvanceError.fileNotWritable
         }
@@ -142,9 +140,7 @@ public final class CacheAdvance<T: Codable> {
     /// - Returns: `true` when there are no messages written to the file.
     public func isEmpty() throws -> Bool {
         try setUpFileHandlesIfNecessary()
-        guard try header.canOpenFile() else {
-            throw CacheAdvanceError.incompatibleHeader
-        }
+        try header.openFile()
 
         return header.offsetInFileAtEndOfNewestMessage == FileHeader.expectedEndOfHeaderInFile
     }
@@ -152,9 +148,7 @@ public final class CacheAdvance<T: Codable> {
     /// Fetches all messages from the cache.
     public func messages() throws -> [T] {
         try setUpFileHandlesIfNecessary()
-        guard try header.canOpenFile() else {
-            throw CacheAdvanceError.incompatibleHeader
-        }
+        try header.openFile()
 
         var messages = [T]()
         while let encodedMessage = try reader.nextEncodedMessage() {

--- a/Sources/CacheAdvance/CacheAdvanceError.swift
+++ b/Sources/CacheAdvance/CacheAdvanceError.swift
@@ -21,6 +21,7 @@ public enum CacheAdvanceError: Error, Equatable {
     /// Thrown when a message being appended to a cache that does not overwrite old messages is too large to store in the remaining space.
     case messageLargerThanRemainingCacheSize
     /// Thrown when a cache's persisted header is incompatible with the current implementation.
+    /// - Parameter persistedVersion: The header version of the file being read.
     case incompatibleHeader(persistedVersion: UInt8)
     /// Thrown when the cache file's persisted static header data is inconsistent with the metadata with which the cache was initialized.
     case fileNotWritable

--- a/Sources/CacheAdvance/CacheAdvanceError.swift
+++ b/Sources/CacheAdvance/CacheAdvanceError.swift
@@ -21,7 +21,7 @@ public enum CacheAdvanceError: Error, Equatable {
     /// Thrown when a message being appended to a cache that does not overwrite old messages is too large to store in the remaining space.
     case messageLargerThanRemainingCacheSize
     /// Thrown when a cache's persisted header is incompatible with the current implementation.
-    case incompatibleHeader
+    case incompatibleHeader(persistedVersion: UInt8)
     /// Thrown when the cache file's persisted static header data is inconsistent with the metadata with which the cache was initialized.
     case fileNotWritable
     /// Thrown when the cache file is of an unexpected format.

--- a/Sources/CacheAdvance/CacheHeaderHandle.swift
+++ b/Sources/CacheAdvance/CacheHeaderHandle.swift
@@ -77,8 +77,8 @@ final class CacheHeaderHandle {
     /// Throws if the expected header version does not match the persisted header version.
     ///
     /// - Throws: `CacheAdvanceError.incompatibleHeader` if this object's header version does not match that of `fileHeader`. May also throw a file reading error if the file can not be read.
-    func openFile() throws {
-        try openFile(with: try memoizedMetadata())
+    func checkFile() throws {
+        try checkFile(with: try memoizedMetadata())
     }
 
     /// Checks if the all the header metadata provided at initialization matches the persisted header.
@@ -107,7 +107,7 @@ final class CacheHeaderHandle {
 
         let persistedMetadata = Metadata(fileHeader: fileHeader)
         do {
-            try openFile(with: persistedMetadata)
+            try checkFile(with: persistedMetadata)
         } catch {
             return
         }
@@ -148,7 +148,7 @@ final class CacheHeaderHandle {
     ///
     /// - Parameter persistedMetadata: The persisted header metadata.
     /// - Throws: `CacheAdvanceError.incompatibleHeader` if this object's header version does not match that of `fileHeader`. May also throw a file reading error if the file can not be read.
-    private func openFile(with persistedMetadata: Metadata) throws {
+    private func checkFile(with persistedMetadata: Metadata) throws {
         // Our current file header version is 1.
         // That means there is only one header version we can understand.
         // Our header version must be our expected version for us to open the file successfully.
@@ -163,7 +163,7 @@ final class CacheHeaderHandle {
     /// - Returns: `true` if this object's static metadata matches that of the persisted `fileHeader`; otherwise `false`.
     private func canWriteToFile(with persistedMetadata: Metadata) -> Bool {
         do {
-            try openFile(with: persistedMetadata)
+            try checkFile(with: persistedMetadata)
         } catch {
             // If we can't open the file, we can't write to it.
             return false

--- a/Sources/CacheAdvance/CacheHeaderHandle.swift
+++ b/Sources/CacheAdvance/CacheHeaderHandle.swift
@@ -74,7 +74,7 @@ final class CacheHeaderHandle {
         try handle.write(data: expectedHeader.data(for: .offsetInFileAtEndOfNewestMessage))
     }
 
-    /// Throws if the expected header version does not match the persisted header version.
+    /// Checks that the file is formatted as expected.
     ///
     /// - Throws: `CacheAdvanceError.incompatibleHeader` if this object's header version does not match that of `fileHeader`. May also throw a file reading error if the file can not be read.
     func checkFile() throws {
@@ -144,7 +144,7 @@ final class CacheHeaderHandle {
         return try handle.readDataUp(toLength: Int(FileHeader.expectedEndOfHeaderInFile))
     }
 
-    /// Throws if the expected header version does not match the persisted header version.
+    /// Checks that the file's persisted metadata has the expected values.
     ///
     /// - Parameter persistedMetadata: The persisted header metadata.
     /// - Throws: `CacheAdvanceError.incompatibleHeader` if this object's header version does not match that of `fileHeader`. May also throw a file reading error if the file can not be read.

--- a/Sources/CacheAdvance/CacheHeaderHandle.swift
+++ b/Sources/CacheAdvance/CacheHeaderHandle.swift
@@ -147,7 +147,7 @@ final class CacheHeaderHandle {
     /// Checks that the file's persisted metadata has the expected values.
     ///
     /// - Parameter persistedMetadata: The persisted header metadata.
-    /// - Throws: `CacheAdvanceError.incompatibleHeader` if this object's header version does not match that of `fileHeader`. May also throw a file reading error if the file can not be read.
+    /// - Throws: `CacheAdvanceError.incompatibleHeader` if this object's header version does not match that of `fileHeader`.
     private func checkFile(with persistedMetadata: Metadata) throws {
         // Our current file header version is 1.
         // That means there is only one header version we can understand.

--- a/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
+++ b/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
@@ -78,7 +78,7 @@ final class CacheAdvanceTests: XCTestCase {
 
         let sut = try createCache(overwritesOldMessages: false)
         XCTAssertThrowsError(try sut.isEmpty()) {
-            XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.incompatibleHeader)
+            XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.incompatibleHeader(persistedVersion: 0))
         }
     }
 
@@ -355,7 +355,7 @@ final class CacheAdvanceTests: XCTestCase {
             sizedToFit: TestableMessage.lorumIpsum.dropLast(),
             overwritesOldMessages: false)
         XCTAssertThrowsError(try sut.append(message: TestableMessage.lorumIpsum.last!)) {
-            XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.incompatibleHeader)
+            XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.incompatibleHeader(persistedVersion: 0))
         }
     }
 
@@ -480,7 +480,7 @@ final class CacheAdvanceTests: XCTestCase {
 
         let sut = try createCache(overwritesOldMessages: false)
         XCTAssertThrowsError(try sut.messages()) {
-            XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.incompatibleHeader)
+            XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.incompatibleHeader(persistedVersion: 0))
         }
     }
 

--- a/Tests/CacheAdvanceTests/CacheHeaderHandleTests.swift
+++ b/Tests/CacheAdvanceTests/CacheHeaderHandleTests.swift
@@ -113,7 +113,7 @@ final class CacheHeaderHandleTests: XCTestCase {
         try handle.closeHandle()
     }
 
-    func test_canOpenFile_versionMismatch_returnsFalse() throws {
+    func test_openFile_versionMismatch_throwsIncompatibleHeader() throws {
         let originalHeader = try createHeaderHandle(
             maximumBytes: 1000,
             overwritesOldMessages: true,
@@ -125,16 +125,18 @@ final class CacheHeaderHandleTests: XCTestCase {
             overwritesOldMessages: true,
             version: 2)
 
-        XCTAssertFalse(try sut.canOpenFile())
+        XCTAssertThrowsError(try sut.openFile()) {
+            XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.incompatibleHeader(persistedVersion: 1))
+        }
     }
 
-    func test_canOpenFile_emptyFile_throwsFileCorrupted() throws {
+    func test_openFile_emptyFile_throwsFileCorrupted() throws {
         let sut = try createHeaderHandle(
             maximumBytes: 1000,
             overwritesOldMessages: true,
             version: 2)
 
-        XCTAssertThrowsError(try sut.canOpenFile()) {
+        XCTAssertThrowsError(try sut.openFile()) {
             XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.fileCorrupted)
         }
     }
@@ -195,7 +197,7 @@ final class CacheHeaderHandleTests: XCTestCase {
         }
     }
 
-    func test_canOpenFile_noMismatches_returnsTrue() throws {
+    func test_openFile_noMismatches_doesNotThrow() throws {
         let originalHeader = try createHeaderHandle(
             maximumBytes: 1000,
             overwritesOldMessages: true,
@@ -207,7 +209,7 @@ final class CacheHeaderHandleTests: XCTestCase {
             overwritesOldMessages: true,
             version: 1)
 
-        XCTAssertTrue(try sut.canOpenFile())
+        XCTAssertNoThrow(try sut.openFile())
     }
 
     // MARK: Private

--- a/Tests/CacheAdvanceTests/CacheHeaderHandleTests.swift
+++ b/Tests/CacheAdvanceTests/CacheHeaderHandleTests.swift
@@ -113,7 +113,7 @@ final class CacheHeaderHandleTests: XCTestCase {
         try handle.closeHandle()
     }
 
-    func test_openFile_versionMismatch_throwsIncompatibleHeader() throws {
+    func test_checkFile_versionMismatch_throwsIncompatibleHeader() throws {
         let originalHeader = try createHeaderHandle(
             maximumBytes: 1000,
             overwritesOldMessages: true,
@@ -125,18 +125,18 @@ final class CacheHeaderHandleTests: XCTestCase {
             overwritesOldMessages: true,
             version: 2)
 
-        XCTAssertThrowsError(try sut.openFile()) {
+        XCTAssertThrowsError(try sut.checkFile()) {
             XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.incompatibleHeader(persistedVersion: 1))
         }
     }
 
-    func test_openFile_emptyFile_throwsFileCorrupted() throws {
+    func test_checkFile_emptyFile_throwsFileCorrupted() throws {
         let sut = try createHeaderHandle(
             maximumBytes: 1000,
             overwritesOldMessages: true,
             version: 2)
 
-        XCTAssertThrowsError(try sut.openFile()) {
+        XCTAssertThrowsError(try sut.checkFile()) {
             XCTAssertEqual($0 as? CacheAdvanceError, CacheAdvanceError.fileCorrupted)
         }
     }
@@ -197,7 +197,7 @@ final class CacheHeaderHandleTests: XCTestCase {
         }
     }
 
-    func test_openFile_noMismatches_doesNotThrow() throws {
+    func test_checkFile_noMismatches_doesNotThrow() throws {
         let originalHeader = try createHeaderHandle(
             maximumBytes: 1000,
             overwritesOldMessages: true,
@@ -209,7 +209,7 @@ final class CacheHeaderHandleTests: XCTestCase {
             overwritesOldMessages: true,
             version: 1)
 
-        XCTAssertNoThrow(try sut.openFile())
+        XCTAssertNoThrow(try sut.checkFile())
     }
 
     // MARK: Private


### PR DESCRIPTION
This PR enables propagating the header version of the file being read as an associated value of the `CacheAdvanceError.incompatibleHeader` error. In order to do this, I've changed the signature of `func canOpenFile(...) -> Bool` to `func checkFile(...) throws` to push error throwing down the stack to where comparisons are being done and header version data is available.

Since we're adding new information to the incompatible header error, I'm considering this to be a feature version bump. This change is technically breaking to code that creates their own `incompatibleHeader` error, but since doing that outside of `CacheAdvance` doesn't make much sense I don't think this PR warrants a major version bump.