### PR TITLE
Remove build tag from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # CacheAdvance
 
-[![CI Status](https://travis-ci.com/dfed/CacheAdvance.svg?branch=main)](https://travis-ci.com/dfed/CacheAdvance)
 [![Swift Package Manager compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://github.com/apple/swift-package-manager)
 [![Version](https://img.shields.io/cocoapods/v/CacheAdvance.svg)](https://cocoapods.org/pods/CacheAdvance)
 [![License](https://img.shields.io/cocoapods/l/CacheAdvance.svg)](https://cocoapods.org/pods/CacheAdvance)


### PR DESCRIPTION
Now that we're off TravisCI, we should remove our README badge that points at travis