### PR TITLE
Update CI to run on macOS 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,4 +116,4 @@ jobs:
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_13.4.1.app/Contents/Developer
       - name: Build and Test Framework
-        run: swift test -c release -Xswiftc -enable-testing
+        run: xcrun swift test -c release -Xswiftc -enable-testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,14 @@ jobs:
       - name: Build Framework
         run: swift package generate-xcodeproj --output generated/ && carthage build --project-directory generated/ --verbose --no-skip-current
   spm-11:
-    name: SPM Build Xcode 11
+    name: Build Xcode 11
     runs-on: macOS-11
     strategy:
       matrix:
         platforms: [
           'iOS_12,tvOS_12',
           'iOS_13,tvOS_13,watchOS_6',
-          'macOS_11'
+          'macOS_10_15',
         ]
       fail-fast: false
     steps:
@@ -59,12 +59,13 @@ jobs:
         if: success()
         run: Scripts/upload-coverage-reports.sh ${{ matrix.platforms }}
   spm-12:
-    name: SPM Build Xcode 12
+    name: Build Xcode 12
     runs-on: macOS-11
     strategy:
       matrix:
         platforms: [
           'iOS_14,tvOS_14,watchOS_7',
+          'macOS_11',
         ]
       fail-fast: false
     steps:
@@ -81,3 +82,39 @@ jobs:
       - name: Upload Coverage Reports
         if: success()
         run: Scripts/upload-coverage-reports.sh ${{ matrix.platforms }}
+  spm-13:
+    name: Build Xcode 13
+    runs-on: macOS-12
+    strategy:
+      matrix:
+        platforms: [
+          'iOS_15,tvOS_15,watchOS_8',
+          'macOS_12',
+        ]
+      fail-fast: false
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Bundle Install
+        run: bundle install
+      - name: Select Xcode Version
+        run: sudo xcode-select --switch /Applications/Xcode_13.4.1.app/Contents/Developer
+      - name: Prepare Simulator Runtimes
+        run: Scripts/github/prepare-simulators.sh ${{ matrix.platforms }}
+      - name: Build and Test Framework
+        run: Scripts/build.swift ${{ matrix.platforms }}
+      - name: Upload Coverage Reports
+        if: success()
+        run: Scripts/upload-coverage-reports.sh ${{ matrix.platforms }}
+  spm-13-swift:
+    name: Swift Build Xcode 13
+    runs-on: macOS-12
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Bundle Install
+        run: bundle install
+      - name: Select Xcode Version
+        run: sudo xcode-select --switch /Applications/Xcode_13.4.1.app/Contents/Developer
+      - name: Build and Test Framework
+        run: swift test -c release -Xswiftc -enable-testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_11.7.app/Contents/Developer
+        run: xcversion select 11.7
       - name: Lint Podspec
         run: bundle exec pod lib lint --verbose --fail-fast --swift-version=5.1
   carthage:
@@ -28,7 +28,7 @@ jobs:
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_11.7.app/Contents/Developer
+        run: xcversion select 11.7
       - name: Install Carthage
         run: brew outdated carthage || brew upgrade carthage
       - name: Build Framework
@@ -49,7 +49,7 @@ jobs:
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_11.7.app/Contents/Developer
+        run: xcversion select 11.7
       - name: Prepare Simulator Runtimes
         run: Scripts/github/prepare-simulators.sh ${{ matrix.platforms }}
       - name: Build and Test Framework
@@ -73,7 +73,7 @@ jobs:
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_12.4.app/Contents/Developer
+        run: xcversion select 12.4
       - name: Prepare Simulator Runtimes
         run: Scripts/github/prepare-simulators.sh ${{ matrix.platforms }}
       - name: Build and Test Framework
@@ -97,7 +97,7 @@ jobs:
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_13.4.1.app/Contents/Developer
+        run: xcversion select 13.4.1
       - name: Prepare Simulator Runtimes
         run: Scripts/github/prepare-simulators.sh ${{ matrix.platforms }}
       - name: Build and Test Framework
@@ -114,6 +114,6 @@ jobs:
       - name: Bundle Install
         run: bundle install
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_13.4.1.app/Contents/Developer
+        run: xcversion select 13.4.1
       - name: Build and Test Framework
         run: xcrun swift test -c release -Xswiftc -enable-testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
     strategy:
       matrix:
         platforms: [
-          'iOS_12,tvOS_12',
           'iOS_13,tvOS_13,watchOS_6',
           'macOS_10_15',
         ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   pod-lint:
     name: Pod Lint
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
         run: bundle exec pod lib lint --verbose --fail-fast --swift-version=5.1
   carthage:
     name: Carthage
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -35,13 +35,13 @@ jobs:
         run: swift package generate-xcodeproj --output generated/ && carthage build --project-directory generated/ --verbose --no-skip-current
   spm-11:
     name: SPM Build Xcode 11
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     strategy:
       matrix:
         platforms: [
           'iOS_12,tvOS_12',
           'iOS_13,tvOS_13,watchOS_6',
-          'macOS_10_15'
+          'macOS_11'
         ]
       fail-fast: false
     steps:
@@ -60,7 +60,7 @@ jobs:
         run: Scripts/upload-coverage-reports.sh ${{ matrix.platforms }}
   spm-12:
     name: SPM Build Xcode 12
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     strategy:
       matrix:
         platforms: [

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -21,11 +21,9 @@ enum TaskError: Error {
 }
 
 enum Platform: String, CaseIterable, CustomStringConvertible {
-    case iOS_12
     case iOS_13
     case iOS_14
     case iOS_15
-    case tvOS_12
     case tvOS_13
     case tvOS_14
     case tvOS_15
@@ -39,8 +37,6 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
 
     var destination: String {
         switch self {
-        case .iOS_12:
-            return "platform=iOS Simulator,OS=12.4,name=iPad Pro (12.9-inch) (3rd generation)"
         case .iOS_13:
             return "platform=iOS Simulator,OS=13.7,name=iPad Pro (12.9-inch) (4th generation)"
         case .iOS_14:
@@ -48,8 +44,6 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
         case .iOS_15:
             return "platform=iOS Simulator,OS=15.5,name=iPad Pro (12.9-inch) (5th generation)"
 
-        case .tvOS_12:
-            return "platform=tvOS Simulator,OS=12.4,name=Apple TV"
         case .tvOS_13:
             return "platform=tvOS Simulator,OS=13.4,name=Apple TV"
         case .tvOS_14:
@@ -75,14 +69,12 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
 
     var sdk: String {
         switch self {
-        case .iOS_12,
-             .iOS_13,
+        case .iOS_13,
              .iOS_14,
              .iOS_15:
             return "iphonesimulator"
 
-        case .tvOS_12,
-             .tvOS_13,
+        case .tvOS_13,
              .tvOS_14,
              .tvOS_15:
             return "appletvsimulator"
@@ -104,11 +96,9 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
 
     var shouldTest: Bool {
         switch self {
-        case .iOS_12,
-             .iOS_13,
+        case .iOS_13,
              .iOS_14,
              .iOS_15,
-             .tvOS_12,
              .tvOS_13,
              .tvOS_14,
              .tvOS_15,
@@ -128,10 +118,8 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
 
     var shouldGenerateXcodeproj: Bool {
         switch self {
-        case .iOS_12,
-             .iOS_13,
+        case .iOS_13,
              .iOS_14,
-             .tvOS_12,
              .tvOS_13,
              .tvOS_14,
              .macOS_10_15,

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -24,13 +24,18 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
     case iOS_12
     case iOS_13
     case iOS_14
+    case iOS_15
     case tvOS_12
     case tvOS_13
     case tvOS_14
+    case tvOS_15
     case macOS_10_15
+    case macOS_11
+    case macOS_12
     case watchOS_5
     case watchOS_6
     case watchOS_7
+    case watchOS_8
 
     var destination: String {
         switch self {
@@ -40,6 +45,8 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
             return "platform=iOS Simulator,OS=13.7,name=iPad Pro (12.9-inch) (4th generation)"
         case .iOS_14:
             return "platform=iOS Simulator,OS=14.4,name=iPad Pro (12.9-inch) (4th generation)"
+        case .iOS_15:
+            return "platform=iOS Simulator,OS=15.5,name=iPad Pro (12.9-inch) (5th generation)"
 
         case .tvOS_12:
             return "platform=tvOS Simulator,OS=12.4,name=Apple TV"
@@ -47,8 +54,12 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
             return "platform=tvOS Simulator,OS=13.4,name=Apple TV"
         case .tvOS_14:
             return "platform=tvOS Simulator,OS=14.3,name=Apple TV"
+        case .tvOS_15:
+            return "platform=tvOS Simulator,OS=15.4,name=Apple TV"
 
-        case .macOS_10_15:
+        case .macOS_10_15,
+             .macOS_11,
+             .macOS_12:
             return "platform=OS X"
 
         case .watchOS_5:
@@ -57,6 +68,8 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
             return "OS=6.2.1,name=Apple Watch Series 4 - 44mm"
         case .watchOS_7:
             return "OS=7.2,name=Apple Watch Series 6 - 44mm"
+        case .watchOS_8:
+            return "OS=8.5,name=Apple Watch Series 6 - 44mm"
         }
     }
 
@@ -64,20 +77,27 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
         switch self {
         case .iOS_12,
              .iOS_13,
-             .iOS_14:
+             .iOS_14,
+             .iOS_15:
             return "iphonesimulator"
 
         case .tvOS_12,
              .tvOS_13,
-             .tvOS_14:
+             .tvOS_14,
+             .tvOS_15:
             return "appletvsimulator"
 
         case .macOS_10_15:
             return "macosx10.15"
+        case .macOS_11:
+            return "macosx11.1"
+        case .macOS_12:
+            return "macosx12.3"
 
         case .watchOS_5,
              .watchOS_6,
-             .watchOS_7:
+             .watchOS_7,
+             .watchOS_8:
             return "watchsimulator"
         }
     }
@@ -87,16 +107,45 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
         case .iOS_12,
              .iOS_13,
              .iOS_14,
+             .iOS_15,
              .tvOS_12,
              .tvOS_13,
              .tvOS_14,
-             .macOS_10_15:
+             .tvOS_15,
+             .macOS_10_15,
+             .macOS_11,
+             .macOS_12:
             return true
 
         case .watchOS_5,
              .watchOS_6,
-             .watchOS_7:
+             .watchOS_7,
+             .watchOS_8:
             // watchOS does not support unit testing (yet?).
+            return false
+        }
+    }
+
+    var shouldGenerateXcodeproj: Bool {
+        switch self {
+        case .iOS_12,
+             .iOS_13,
+             .iOS_14,
+             .tvOS_12,
+             .tvOS_13,
+             .tvOS_14,
+             .macOS_10_15,
+             .macOS_11,
+             .watchOS_5,
+             .watchOS_6,
+             .watchOS_7:
+            return true
+
+        case .iOS_15,
+             .tvOS_15,
+             .macOS_12,
+             .watchOS_8:
+            // Xcode 13 does not require xcodeproj generation
             return false
         }
     }
@@ -115,31 +164,43 @@ guard CommandLine.arguments.count > 1 else {
     throw TaskError.code(1)
 }
 
-try execute(commandPath: "/usr/bin/swift", arguments: ["package", "generate-xcodeproj", "--output=generated/"])
-
-// The generate-xcodeproj command has a bug where the test deployment target is above the minimum deployment target for the project. Fix it with sed.
-try execute(commandPath: "/usr/bin/sed", arguments: ["-i", "-e", "s/IPHONEOS_DEPLOYMENT_TARGET = \"14.0\"/IPHONEOS_DEPLOYMENT_TARGET = \"12.0\"/g", "generated/CacheAdvance.xcodeproj/project.pbxproj"])
-try execute(commandPath: "/usr/bin/sed", arguments: ["-i", "-e", "s/TVOS_DEPLOYMENT_TARGET = \"14.0\"/TVOS_DEPLOYMENT_TARGET = \"12.0\"/g", "generated/CacheAdvance.xcodeproj/project.pbxproj"])
-try execute(commandPath: "/usr/bin/sed", arguments: ["-i", "-e", "s/WATCHOS_DEPLOYMENT_TARGET = \"7.0\"/MACOSX_DEPLOYMENT_TARGET = \"5.0\"/g", "generated/CacheAdvance.xcodeproj/project.pbxproj"])
-try execute(commandPath: "/usr/bin/sed", arguments: ["-i", "-e", "s/MACOSX_DEPLOYMENT_TARGET = \"11.0\"/MACOSX_DEPLOYMENT_TARGET = \"10.15\"/g", "generated/CacheAdvance.xcodeproj/project.pbxproj"])
-
 let rawPlatforms = CommandLine.arguments[1].components(separatedBy: ",")
 
+var isFirstRun = true
 for rawPlatform in rawPlatforms {
     guard let platform = Platform(rawValue: rawPlatform) else {
         print("Received unknown platform type \(rawPlatform)")
         print("Possible platform types are: \(Platform.allCases)")
         throw TaskError.code(1)
     }
+
+    if isFirstRun && platform.shouldGenerateXcodeproj {
+        // Generate the xcode project if we need it
+        try execute(commandPath: "/usr/bin/swift", arguments: ["package", "generate-xcodeproj", "--output=generated/"])
+
+        // The generate-xcodeproj command has a bug where the test deployment target is above the minimum deployment target for the project. Fix it with sed.
+        try execute(commandPath: "/usr/bin/sed", arguments: ["-i", "-e", "s/IPHONEOS_DEPLOYMENT_TARGET = \"14.0\"/IPHONEOS_DEPLOYMENT_TARGET = \"12.0\"/g", "generated/CacheAdvance.xcodeproj/project.pbxproj"])
+        try execute(commandPath: "/usr/bin/sed", arguments: ["-i", "-e", "s/TVOS_DEPLOYMENT_TARGET = \"14.0\"/TVOS_DEPLOYMENT_TARGET = \"12.0\"/g", "generated/CacheAdvance.xcodeproj/project.pbxproj"])
+        try execute(commandPath: "/usr/bin/sed", arguments: ["-i", "-e", "s/WATCHOS_DEPLOYMENT_TARGET = \"7.0\"/MACOSX_DEPLOYMENT_TARGET = \"5.0\"/g", "generated/CacheAdvance.xcodeproj/project.pbxproj"])
+        try execute(commandPath: "/usr/bin/sed", arguments: ["-i", "-e", "s/MACOSX_DEPLOYMENT_TARGET = \"11.0\"/MACOSX_DEPLOYMENT_TARGET = \"11.0\"/g", "generated/CacheAdvance.xcodeproj/project.pbxproj"])
+    }
+
     var xcodeBuildArguments = [
-        "-project", "generated/CacheAdvance.xcodeproj",
         "-scheme", "CacheAdvance-Package",
         "-sdk", platform.sdk,
-        "-configuration", "Release",
         "-derivedDataPath", platform.derivedDataPath,
-        "-PBXBuildsContinueAfterErrors=0",
-        "OTHER_CFLAGS='-DGENERATED_XCODE_PROJECT'",
+        "-PBXBuildsContinueAfterErrors=0"
     ]
+    if platform.shouldGenerateXcodeproj {
+        // Point at the generated project
+        xcodeBuildArguments.append("-project")
+        xcodeBuildArguments.append("generated/CacheAdvance.xcodeproj")
+        // Set the configuration to be release – this configuration is not supported when running xcodebuild without a xcodeproj file.
+        xcodeBuildArguments.append("-configuration")
+        xcodeBuildArguments.append("Release")
+        // Set a compiler flag to enable a xcodeproj-specific build flag.
+        xcodeBuildArguments.append("OTHER_CFLAGS='-DGENERATED_XCODE_PROJECT'")
+    }
     if !platform.destination.isEmpty {
         xcodeBuildArguments.append("-destination")
         xcodeBuildArguments.append(platform.destination)
@@ -154,4 +215,5 @@ for rawPlatform in rawPlatforms {
     }
 
     try execute(commandPath: "/usr/bin/xcodebuild", arguments: xcodeBuildArguments)
+    isFirstRun = false
 }

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -30,7 +30,6 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
     case macOS_10_15
     case macOS_11
     case macOS_12
-    case watchOS_5
     case watchOS_6
     case watchOS_7
     case watchOS_8
@@ -56,8 +55,6 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
              .macOS_12:
             return "platform=OS X"
 
-        case .watchOS_5:
-            return "OS=5.3,name=Apple Watch Series 4 - 44mm"
         case .watchOS_6:
             return "OS=6.2.1,name=Apple Watch Series 4 - 44mm"
         case .watchOS_7:
@@ -86,8 +83,7 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
         case .macOS_12:
             return "macosx12.3"
 
-        case .watchOS_5,
-             .watchOS_6,
+        case .watchOS_6,
              .watchOS_7,
              .watchOS_8:
             return "watchsimulator"
@@ -107,8 +103,7 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
              .macOS_12:
             return true
 
-        case .watchOS_5,
-             .watchOS_6,
+        case .watchOS_6,
              .watchOS_7,
              .watchOS_8:
             // watchOS does not support unit testing (yet?).
@@ -124,7 +119,6 @@ enum Platform: String, CaseIterable, CustomStringConvertible {
              .tvOS_14,
              .macOS_10_15,
              .macOS_11,
-             .watchOS_5,
              .watchOS_6,
              .watchOS_7:
             return true

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -163,7 +163,7 @@ for rawPlatform in rawPlatforms {
         // The generate-xcodeproj command has a bug where the test deployment target is above the minimum deployment target for the project. Fix it with sed.
         try execute(commandPath: "/usr/bin/sed", arguments: ["-i", "-e", "s/IPHONEOS_DEPLOYMENT_TARGET = \"14.0\"/IPHONEOS_DEPLOYMENT_TARGET = \"12.0\"/g", "generated/CacheAdvance.xcodeproj/project.pbxproj"])
         try execute(commandPath: "/usr/bin/sed", arguments: ["-i", "-e", "s/TVOS_DEPLOYMENT_TARGET = \"14.0\"/TVOS_DEPLOYMENT_TARGET = \"12.0\"/g", "generated/CacheAdvance.xcodeproj/project.pbxproj"])
-        try execute(commandPath: "/usr/bin/sed", arguments: ["-i", "-e", "s/WATCHOS_DEPLOYMENT_TARGET = \"7.0\"/MACOSX_DEPLOYMENT_TARGET = \"5.0\"/g", "generated/CacheAdvance.xcodeproj/project.pbxproj"])
+        try execute(commandPath: "/usr/bin/sed", arguments: ["-i", "-e", "s/WATCHOS_DEPLOYMENT_TARGET = \"7.0\"/WATCHOS_DEPLOYMENT_TARGET = \"5.0\"/g", "generated/CacheAdvance.xcodeproj/project.pbxproj"])
         try execute(commandPath: "/usr/bin/sed", arguments: ["-i", "-e", "s/MACOSX_DEPLOYMENT_TARGET = \"11.0\"/MACOSX_DEPLOYMENT_TARGET = \"11.0\"/g", "generated/CacheAdvance.xcodeproj/project.pbxproj"])
     }
 

--- a/Scripts/github/prepare-simulators.sh
+++ b/Scripts/github/prepare-simulators.sh
@@ -9,16 +9,8 @@ if [[ ${PLATFORMS[*]} =~ 'iOS_13' ]]; then
 	sudo ln -s /Applications/Xcode_11.7.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 13.7.simruntime
 fi
 
-if [[ ${PLATFORMS[*]} =~ 'iOS_12' ]]; then
-	sudo ln -s /Applications/Xcode_10.3.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 12.4.simruntime
-fi
-
 if [[ ${PLATFORMS[*]} =~ 'tvOS_13' ]]; then
 	sudo ln -s /Applications/Xcode_11.7.app/Contents/Developer/Platforms/AppleTVOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS\ 13.4.simruntime
-fi
-
-if [[ ${PLATFORMS[*]} =~ 'tvOS_12' ]]; then
-	sudo ln -s /Applications/Xcode_10.3.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/tvOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS\ 12.4.simruntime
 fi
 
 xcrun simctl list runtimes

--- a/Sources/CacheAdvance/BigEndianHostSwappable.swift
+++ b/Sources/CacheAdvance/BigEndianHostSwappable.swift
@@ -31,10 +31,10 @@ extension BigEndianHostSwappable {
     ///
     /// - Parameter data: A data blob representing encodable data. Must be of length `Self.storageLength`.
     init(_ data: Data) {
-        let decodedSize = withUnsafePointer(to: data) {
-            return UnsafeRawBufferPointer(start: $0, count: Self.storageLength)
+        let decodedSize = data.withUnsafeBytes {
+            return $0.load(as: Self.self)
         }
-        self = Self.swapToHost(decodedSize.load(as: Self.self))
+        self = Self.swapToHost(decodedSize)
     }
 
     /// The length of a contiguous data blob required to store this type.


### PR DESCRIPTION
macOS 10.15 [is no longer supported by Github Actions](https://github.com/actions/runner-images/blob/main/images/macos/macos-10.15-Readme.md). So instead let's run CI on macOS 11 and macOS 12.

While I was here, I also added Xcode 13 CI runs, and resolved #44