### PR TITLE
Add readerForwardOnly to CacheAdvance init parameter to avoid possible infinite loop

### DIFF
--- a/Sources/CacheAdvance/CacheAdvance.swift
+++ b/Sources/CacheAdvance/CacheAdvance.swift
@@ -29,6 +29,7 @@ public final class CacheAdvance<T: Codable> {
     ///   - fileURL: The file URL indicating the desired location of the on-disk store. This file should already exist.
     ///   - maximumBytes: The maximum size of the cache, in bytes. Logs larger than this size will fail to append to the store.
     ///   - shouldOverwriteOldMessages: When `true`, once the on-disk store exceeds maximumBytes, new entries will replace the oldest entry.
+    ///   - readerForwardOnly: When `true`, the file handle cursor won't move backward to the current offset to avoid possible infinite loop when reading messages()
     ///   - decoder: The decoder that will be used to decode already-persisted messages.
     ///   - encoder: The encoder that will be used to encode messages prior to persistence.
     ///
@@ -40,6 +41,7 @@ public final class CacheAdvance<T: Codable> {
         fileURL: URL,
         maximumBytes: Bytes,
         shouldOverwriteOldMessages: Bool,
+        readerForwardOnly: Bool = false,
         decoder: MessageDecoder = JSONDecoder(),
         encoder: MessageEncoder = JSONEncoder())
         throws
@@ -47,7 +49,7 @@ public final class CacheAdvance<T: Codable> {
         self.init(
             fileURL: fileURL,
             writer: try FileHandle(forWritingTo: fileURL),
-            reader: try CacheReader(forReadingFrom: fileURL),
+            reader: try CacheReader(forReadingFrom: fileURL, seekForwardOnly: readerForwardOnly),
             header: try CacheHeaderHandle(
                 forReadingFrom: fileURL,
                 maximumBytes: maximumBytes,

--- a/Sources/CacheAdvance/CacheReader.swift
+++ b/Sources/CacheAdvance/CacheReader.swift
@@ -65,10 +65,12 @@ final class CacheReader {
                 // If the previous read was also empty, then the file has been corrupted.
                 throw CacheAdvanceError.fileCorrupted
             }
-            if seekForwardOnly && startingOffset > FileHeader.expectedEndOfHeaderInFile {
-                // If seekForwardOnly is true, then return nil when startingOffset is ahead
-                // Otherwise, there will be an infinite loop in reading messages.
-                return nil
+            if seekForwardOnly {
+                guard startingOffset <= FileHeader.expectedEndOfHeaderInFile else {
+                    // If the startingOffset is ahead of `expectedEndOfHeaderInFile`, return nil to stop reading.
+                    // Otherwise, there will be an infinite loop in reading messages.
+                    return nil
+                }
             }
             // We know the next message is at the end of the file header. Let's seek to it.
             try reader.seek(to: FileHeader.expectedEndOfHeaderInFile)

--- a/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
+++ b/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
@@ -151,7 +151,6 @@ final class CacheAdvanceTests: XCTestCase {
         }
     }
 
-
     func test_isWritable_returnsTrueWhenStaticHeaderMetadataMatches() throws {
         let originalCache = try createCache(overwritesOldMessages: false)
         XCTAssertTrue(try originalCache.isWritable())


### PR DESCRIPTION
Hi @dfed , did you remember the JSON decoding optimization in Jitney? There was OOM increase in the treatment group of Jitney uploader optimization. Finally and hopefully, I fix it this time. Very glad to share this with you, and please take a look at this PR.

This is a brief how this problem got figure out.  I added breadcrumbs before and after `func messages()`.  According to breadcrumbs on bugsnag and Xcode energy reports, I have a hypothesis that there is a possible infinite loop when call `func messages()`. 

Then I investigated the code, and found there is potential infinite loop case when the offset in the header is not correct. Please see the details in the unit tests of the PR.

This recording shows the infinite loop triggered in unit test with one message written:

![infinite_loop](https://user-images.githubusercontent.com/105257537/194757399-27373229-f7b9-426e-b2f9-6750150d690b.gif)

This fix is really last for a long time for me working on this. Hope this times works : )