### PR TITLE
Get codecov working again

### DIFF
--- a/Scripts/upload-coverage-reports.sh
+++ b/Scripts/upload-coverage-reports.sh
@@ -4,6 +4,6 @@ set -ex
 IFS=','; PLATFORMS=$(echo $1); unset IFS
 
 for PLATFORM in $PLATFORMS; do
-	bash <(curl -s https://codecov.io/bash) -J '^CacheAdvance$' -D .build/derivedData/$PLATFORM -t 8344b011-6b2a-4b3d-a573-eaf49684318e
-	bash <(curl -s https://codecov.io/bash) -J '^CADCacheAdvance$' -D .build/derivedData/$PLATFORM -t 8344b011-6b2a-4b3d-a573-eaf49684318e
+	bash <(curl -s https://codecov.io/bash) -J '^CacheAdvance(.framework)?$' -D .build/derivedData/$PLATFORM -t 8344b011-6b2a-4b3d-a573-eaf49684318e
+	bash <(curl -s https://codecov.io/bash) -J '^CADCacheAdvance(.framework)?$' -D .build/derivedData/$PLATFORM -t 8344b011-6b2a-4b3d-a573-eaf49684318e
 done


### PR DESCRIPTION
PRs are no longer getting code coverage reports. It [looks like](https://app.codecov.io/gh/dfed/CacheAdvance/commits) we stopped successfully uploading code coverage reports when we moved to Github Actions:
<img width="1301" alt="image" src="https://user-images.githubusercontent.com/139364/195179623-ad0f546d-0d63-4ab6-9560-779a030f11fe.png">

I'm not sure how that PR broke things, but running locally I see that test runs utilizing swift packages have a `.framework` suffix, and test runs utilizing a generated xcodeproj do not. Fixing this seems to have fixed codecov.