### PR TITLE
Split two ranges to read messages if offsetInFileOfOldestMessage > offsetInFileAtEndOfNewestMessage to avoid possible loop

### DIFF
--- a/CacheAdvance.podspec
+++ b/CacheAdvance.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'CacheAdvance'
-  s.version  = '1.2.3'
+  s.version  = '1.2.5'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A performant cache for logging systems. CacheAdvance persists log events 30x faster than SQLite.'
   s.homepage = 'https://github.com/dfed/CacheAdvance'

--- a/CacheAdvance.podspec
+++ b/CacheAdvance.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'CacheAdvance'
-  s.version  = '1.2.4'
+  s.version  = '1.2.3'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A performant cache for logging systems. CacheAdvance persists log events 30x faster than SQLite.'
   s.homepage = 'https://github.com/dfed/CacheAdvance'

--- a/Sources/CacheAdvance/CacheAdvance.swift
+++ b/Sources/CacheAdvance/CacheAdvance.swift
@@ -47,9 +47,7 @@ public final class CacheAdvance<T: Codable> {
         self.init(
             fileURL: fileURL,
             writer: try FileHandle(forWritingTo: fileURL),
-            reader: try CacheReader(
-                forReadingFrom: fileURL,
-                maximumBytes: maximumBytes),
+            reader: try CacheReader(forReadingFrom: fileURL),
             header: try CacheHeaderHandle(
                 forReadingFrom: fileURL,
                 maximumBytes: maximumBytes,

--- a/Sources/CacheAdvance/FileHeader.swift
+++ b/Sources/CacheAdvance/FileHeader.swift
@@ -79,7 +79,7 @@ struct FileHeader {
     static let version: UInt8 = 1
 
     /// Calculates the offset in the file where the header should end.
-    static var expectedEndOfHeaderInFile = Field(rawValue: Field.allCases.endIndex)!.expectedEndOfFieldInFile
+    static let expectedEndOfHeaderInFile = Field(rawValue: Field.allCases.endIndex)!.expectedEndOfFieldInFile
 
     func data(for field: Field) -> Data {
         switch field {

--- a/Sources/CacheAdvance/FileHeader.swift
+++ b/Sources/CacheAdvance/FileHeader.swift
@@ -79,7 +79,7 @@ struct FileHeader {
     static let version: UInt8 = 1
 
     /// Calculates the offset in the file where the header should end.
-    static let expectedEndOfHeaderInFile = Field(rawValue: Field.allCases.endIndex)!.expectedEndOfFieldInFile
+    static var expectedEndOfHeaderInFile = Field(rawValue: Field.allCases.endIndex)!.expectedEndOfFieldInFile
 
     func data(for field: Field) -> Data {
         switch field {


### PR DESCRIPTION
My concern is there is still this line of code: [`try reader.seek(to: FileHeader.expectedEndOfHeaderInFile)` ](https://github.com/dfed/CacheAdvance/pull/66/files#diff-90b1f5431bb05caf1445ee7ee42e2a66b2bfb2e6fad63f3266cace6cd1389fd6L68), which keeps the possibility to run into an infinite loop. 

Thus, I have a thought to fix this for `shouldOverwriteOldMessages` true | false without the seek back action in this func. 

1. When `shouldOverwriteOldMessages` is true and new_offset < old_offset , split the reader by two ranges according old message offset, new message offset. 
    1.1 Range 1 would be : from old message offset to file end.
    1.2 Range 2 would be: from top to newest offset
2. When `shouldOverwriteOldMessages` is false,  the reader read from top to end.
3. Both of the above situations, we never seek back for next read which can guarantee there is no loop.

@dfed  @bachand 