### PR TITLE
Make ObjectiveCError type Sendable without warnings

### DIFF
--- a/CacheAdvance.podspec
+++ b/CacheAdvance.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'CacheAdvance'
-  s.version  = '1.2.4'
+  s.version  = '1.2.5'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A performant cache for logging systems. CacheAdvance persists log events 30x faster than SQLite.'
   s.homepage = 'https://github.com/dfed/CacheAdvance'

--- a/Sources/CacheAdvance/CacheReader.swift
+++ b/Sources/CacheAdvance/CacheReader.swift
@@ -59,6 +59,7 @@ final class CacheReader {
             }
         }
         if let endOffset = endOffset, offsetInFile < endOffset {
+            // If we finished reading messages but our offset in the file is less than our expected ending offset, this file is corrupted.
             throw CacheAdvanceError.fileCorrupted
         }
         return encodedMessages

--- a/Sources/CacheAdvance/CacheReader.swift
+++ b/Sources/CacheAdvance/CacheReader.swift
@@ -58,7 +58,7 @@ final class CacheReader {
                 }
             }
         }
-        if let endOffset = endOffset, offsetInFile != endOffset {
+        if let endOffset = endOffset, offsetInFile < endOffset {
             throw CacheAdvanceError.fileCorrupted
         }
         return encodedMessages

--- a/Sources/CacheAdvance/CacheReader.swift
+++ b/Sources/CacheAdvance/CacheReader.swift
@@ -54,12 +54,13 @@ final class CacheReader {
                 if offsetInFile == endOffset {
                     break
                 } else if offsetInFile > endOffset {
+                    // The messages on disk are out of sync with our header data.
                     throw CacheAdvanceError.fileCorrupted
                 }
             }
         }
-        if let endOffset = endOffset, offsetInFile < endOffset {
-            // If we finished reading messages but our offset in the file is less than our expected ending offset, this file is corrupted.
+        if let endOffset = endOffset, offsetInFile != endOffset {
+            // If we finished reading messages but our offset in the file is less (or greater) than our expected ending offset, our header data is incorrect.
             throw CacheAdvanceError.fileCorrupted
         }
         return encodedMessages

--- a/Sources/CacheAdvance/ObjectiveC.swift
+++ b/Sources/CacheAdvance/ObjectiveC.swift
@@ -34,7 +34,9 @@ final class ObjectiveC {
         SwiftTryCatch.try({
             result = .success(work())
         }, catch: { exception in
-            result = .failure(ObjectiveCError(exception: exception))
+            result = .failure(ObjectiveCError(
+                exceptionName: exception.name,
+                reason: exception.reason))
         })
 
         switch result {
@@ -51,5 +53,6 @@ struct ObjectiveCTryFailure: Error {}
 
 /// A `throw`able NSException.
 struct ObjectiveCError: Error {
-    let exception: NSException
+    let exceptionName: NSExceptionName
+    let reason: String?
 }


### PR DESCRIPTION
`Error` inherits from `Sendable`, but `NSException` does not conform to `Sendable` (probably due to the `raise()` method?). In order to remove a warning that `ObjectiveCError` does not actually conform to `Sendable` on Xcode 14+, I made `ObjectiveCError` include the exception name and the reason.

Since `ObjectiveCError` is not `public`, this is not a breaking change.