### PR TITLE
Use most up-to-date FileHandle APIs

### DIFF
--- a/CacheAdvance.podspec
+++ b/CacheAdvance.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'CacheAdvance'
-  s.version  = '1.2.4'
+  s.version  = '1.2.5'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'A performant cache for logging systems. CacheAdvance persists log events 30x faster than SQLite.'
   s.homepage = 'https://github.com/dfed/CacheAdvance'

--- a/Sources/CacheAdvance/FileHandleExtensions.swift
+++ b/Sources/CacheAdvance/FileHandleExtensions.swift
@@ -23,7 +23,13 @@ extension FileHandle {
 
     /// A method to read data from a file handle that is safe to call in Swift from any operation system version.
     func readDataUp(toLength length: Int) throws -> Data {
-        if #available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *) {
+        if #available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *) {
+            if let data = try read(upToCount: length) {
+                return data
+            } else {
+                return Data()
+            }
+        } else if #available(iOS 13.0, tvOS 13.0, watchOS 6.2, macOS 10.15, *) {
             return try __readDataUp(toLength: length)
         } else {
             return try ObjectiveC.unsafe { readData(ofLength: length) }
@@ -32,7 +38,9 @@ extension FileHandle {
 
     /// A method to write data to a file handle that is safe to call in Swift from any operation system version.
     func write(data: Data) throws {
-        if #available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *) {
+        if #available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *) {
+            return try write(contentsOf: data)
+        } else if #available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *) {
             return try __write(data, error: ())
         } else {
             return try ObjectiveC.unsafe { write(data) }

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,6 +14,9 @@ coverage:
     patch: off
 
 ignore:
+  # Due to limitations in Github Actions' supported Xcode versions, we can't get good coverage on this file.
   - "Sources/CacheAdvance/FileHandleExtensions.swift"
+  # This package is not shipped and only includes testing helpers.
   - "Sources/LorumIpsum"
+  # This package is not shipped.
   - "Tests"

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,5 +14,6 @@ coverage:
     patch: off
 
 ignore:
+  - "Sources/CacheAdvance/FileHandleExtensions.swift"
   - "Sources/LorumIpsum"
   - "Tests"


### PR DESCRIPTION
When iOS 13 / tvOS 13 / watchOS 6 / macOS 10.15 were released, Apple deprecated the [readData(ofLength:)](https://developer.apple.com/documentation/foundation/filehandle/1413916-readdata) and the [write(_:)](https://developer.apple.com/documentation/foundation/filehandle/1410936-write) methods, but _did not replace them with any new documented methods_. The only available, non-deprecated replacements for these methods were `__readDataUp(toLength:)` and `__write(_:, error:)`, but neither were documented.

Then in iOS 13.4 / tvOS 13.4 / watchOS 6.2 / macOS 10.15.4 Apple fixed their mistake, introducing the APIs [read(upToCount:)](https://developer.apple.com/documentation/foundation/filehandle/3516317-read) and [write(contentsOf:)](https://developer.apple.com/documentation/foundation/filehandle/3516320-write). This PR adopts these newer methods.

It is expected that this PR will lower our code coverage, since we do not have CI running on iOS 13.0<=13.4 / tvOS 13.0<=13.4 / watchOS 6<=6.2 / macOS 10.15.0<=10.15.4