### PR TITLE
Replace actions/setup-ruby@v1 with ruby/setup-ruby@v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Pod Lint
     runs-on: macOS-11
     steps:
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7.6'
       - name: Checkout Repo
@@ -26,7 +26,7 @@ jobs:
     name: Carthage
     runs-on: macOS-11
     steps:
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7.6'
       - name: Checkout Repo
@@ -50,7 +50,7 @@ jobs:
         ]
       fail-fast: false
     steps:
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7.6'
       - name: Checkout Repo
@@ -74,7 +74,7 @@ jobs:
         ]
       fail-fast: false
     steps:
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7.6'
       - name: Checkout Repo
@@ -98,7 +98,7 @@ jobs:
         ]
       fail-fast: false
     steps:
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7.6'
       - name: Checkout Repo
@@ -120,7 +120,7 @@ jobs:
     name: Swift Build Xcode 13
     runs-on: macOS-12
     steps:
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7.6'
       - name: Checkout Repo
@@ -142,7 +142,7 @@ jobs:
         ]
       fail-fast: false
     steps:
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7.6'
       - name: Checkout Repo
@@ -164,7 +164,7 @@ jobs:
     name: Swift Build Xcode 14
     runs-on: macOS-12
     steps:
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7.6'
       - name: Checkout Repo


### PR DESCRIPTION
As title. The former is deprecated and no longer supported.