### PR TITLE
Support Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
   linux:
     name: Build and Test on Linux
     runs-on: ubuntu-latest
-    container: swift:6.0.2
+    container: swift:6.0.3
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,25 @@ jobs:
         run: sudo xcode-select --switch /Applications/Xcode_16.app/Contents/Developer
       - name: Build and Test Framework
         run: xcrun swift test -c release -Xswiftc -enable-testing
+  linux:
+    name: Build and Test on Linux
+    runs-on: ubuntu-latest
+    container: swift:6.0
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Build and Test Framework
+        run: swift test -c release --enable-code-coverage -Xswiftc -enable-testing
+      - name: Prepare Coverage Reports
+        run: |
+          llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/release/CacheAdvancePackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/release/codecov/default.profdata > coverage.lcov
+      - name: Upload Coverage Reports
+        if: success()
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          verbose: true
+          os: linux
   readme-validation:
     name: Check Markdown links
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
   linux:
     name: Build and Test on Linux
     runs-on: ubuntu-latest
-    container: swift:6.0
+    container: swift:6.0.2
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,13 @@ let package = Package(
             name: "CADCacheAdvance",
             targets: ["CADCacheAdvance"]
         ),
-    ],
+    ].filter {
+#if os(Linux)
+        $0.name != "CADCacheAdvance"
+#else
+        true
+#endif
+    },
     targets: [
         .target(
             name: "CacheAdvance",
@@ -59,5 +65,12 @@ let package = Package(
                 .swiftLanguageMode(.v6),
             ]
         ),
-    ]
+    ].filter {
+#if os(Linux)
+        $0.name != "CADCacheAdvance"
+        && $0.name != "CADCacheAdvanceTests"
+#else
+        true
+#endif
+    }
 )

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -93,7 +93,7 @@ for rawPlatform in rawPlatforms {
     }
 
     var xcodeBuildArguments = [
-        "-scheme", "CacheAdvance-Package",
+        "-scheme", "CacheAdvance",
         "-sdk", platform.sdk,
         "-derivedDataPath", platform.derivedDataPath,
         "-PBXBuildsContinueAfterErrors=0",

--- a/Scripts/build.swift
+++ b/Scripts/build.swift
@@ -93,7 +93,7 @@ for rawPlatform in rawPlatforms {
     }
 
     var xcodeBuildArguments = [
-        "-scheme", "CacheAdvance",
+        "-scheme", "CacheAdvance-Package",
         "-sdk", platform.sdk,
         "-derivedDataPath", platform.derivedDataPath,
         "-PBXBuildsContinueAfterErrors=0",

--- a/Sources/CacheAdvance/BigEndianHostSwappable.swift
+++ b/Sources/CacheAdvance/BigEndianHostSwappable.swift
@@ -34,8 +34,9 @@ extension BigEndianHostSwappable {
     ///
     /// - Parameter data: A data blob representing encodable data. Must be of length `Self.storageLength`.
     init(_ data: Data) {
-        let decodedSize = data.withUnsafeBytes {
-            $0.load(as: Self.self)
+        var decodedSize: Self = 0
+        _ = withUnsafeMutableBytes(of: &decodedSize) {
+            data.copyBytes(to: $0, count: data.count)
         }
         self = Self(bigEndian: decodedSize)
     }

--- a/Sources/CacheAdvance/BigEndianHostSwappable.swift
+++ b/Sources/CacheAdvance/BigEndianHostSwappable.swift
@@ -21,7 +21,7 @@ import Foundation
 protocol BigEndianHostSwappable where Self: FixedWidthInteger {
 
     /// Converts the big-endian value in x to the current endian format and returns the resulting value.
-    static func swapToHost(_ x: Self) -> Self
+    init(bigEndian value: Self)
 
     /// The maximum representable integer in this type.
     static var max: Self { get }
@@ -37,7 +37,7 @@ extension BigEndianHostSwappable {
         let decodedSize = data.withUnsafeBytes {
             $0.load(as: Self.self)
         }
-        self = Self.swapToHost(decodedSize)
+        self = Self(bigEndian: decodedSize)
     }
 
     /// The length of a contiguous data blob required to store this type.

--- a/Sources/CacheAdvance/FileHandleExtensions.swift
+++ b/Sources/CacheAdvance/FileHandleExtensions.swift
@@ -23,6 +23,13 @@ extension FileHandle {
 
     /// A method to read data from a file handle that is safe to call in Swift from any operation system version.
     func readDataUp(toLength length: Int) throws -> Data {
+#if os(Linux)
+        if let data = try read(upToCount: length) {
+            data
+        } else {
+            Data()
+        }
+#else
         if #available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *) {
             if let data = try read(upToCount: length) {
                 data
@@ -32,15 +39,20 @@ extension FileHandle {
         } else {
             try __readDataUp(toLength: length)
         }
+#endif
     }
 
     /// A method to write data to a file handle that is safe to call in Swift from any operation system version.
     func write(data: Data) throws {
+#if os(Linux)
+        try write(contentsOf: data)
+#else
         if #available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *) {
             try write(contentsOf: data)
         } else {
             try __write(data, error: ())
         }
+#endif
     }
 
     /// A method to seek on a file handle that is safe to call in Swift from any operation system version.

--- a/Sources/CacheAdvance/UInt32+BigEndianHostSwappable.swift
+++ b/Sources/CacheAdvance/UInt32+BigEndianHostSwappable.swift
@@ -17,10 +17,4 @@
 
 import Foundation
 
-extension UInt32: BigEndianHostSwappable {
-    
-    static func swapToHost(_ x: UInt32) -> UInt32 {
-        NSSwapBigIntToHost(x)
-    }
-    
-}
+extension UInt32: BigEndianHostSwappable {}

--- a/Sources/CacheAdvance/UInt64+BigEndianHostSwappable.swift
+++ b/Sources/CacheAdvance/UInt64+BigEndianHostSwappable.swift
@@ -17,10 +17,4 @@
 
 import Foundation
 
-extension UInt64: BigEndianHostSwappable {
-    
-    static func swapToHost(_ x: UInt64) -> UInt64 {
-        NSSwapBigLongLongToHost(x)
-    }
-
-}
+extension UInt64: BigEndianHostSwappable {}

--- a/Sources/CacheAdvance/UInt8+BigEndianHostSwappable.swift
+++ b/Sources/CacheAdvance/UInt8+BigEndianHostSwappable.swift
@@ -17,10 +17,4 @@
 
 import Foundation
 
-extension UInt8: BigEndianHostSwappable {
-    
-    static func swapToHost(_ x: UInt8) -> UInt8 {
-        x // UInt8 is 1-byte long, so local endianness does not affect storage of this type.
-    }
-    
-}
+extension UInt8: BigEndianHostSwappable {}

--- a/Sources/LorumIpsum/LorumIpsumMessages.swift
+++ b/Sources/LorumIpsum/LorumIpsumMessages.swift
@@ -17,9 +17,7 @@
 
 import Foundation
 
-@objc(CADLorumIpsum)
 public final class LorumIpsum: NSObject {
-    @objc
     public static let messages: [String] = [
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
         "Arcu cursus euismod quis viverra nibh cras pulvinar.",
@@ -503,3 +501,11 @@ public final class LorumIpsum: NSObject {
         "Eu turpis egestas pretium aenean pharetra magna.",
     ]
 }
+
+#if !os(Linux)
+@objc
+public final class CADLorumIpsum: NSObject {
+    @objc
+    public static let messages = LorumIpsum.messages
+}
+#endif

--- a/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
+++ b/Tests/CacheAdvanceTests/CacheAdvanceTests.swift
@@ -726,10 +726,11 @@ final class CacheAdvanceTests: XCTestCase {
     }
 
     private func clearCacheFile() {
-        FileManager.default.createFile(
+        XCTAssertTrue(FileManager.default.createFile(
             atPath: testFileLocation.path,
             contents: nil,
-            attributes: nil)
+            attributes: nil
+        ))
     }
 
     private let testFileLocation = FileManager.default.temporaryDirectory.appendingPathComponent("CacheAdvanceTests")

--- a/Tests/CacheAdvanceTests/CacheHeaderHandleTests.swift
+++ b/Tests/CacheAdvanceTests/CacheHeaderHandleTests.swift
@@ -26,7 +26,7 @@ final class CacheHeaderHandleTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        FileManager.default.createFile(atPath: testFileLocation.path, contents: nil, attributes: nil)
+        XCTAssertTrue(FileManager.default.createFile(atPath: testFileLocation.path, contents: nil, attributes: nil))
     }
 
     override func tearDown() {

--- a/Tests/CacheAdvanceTests/FlushableCachePerformanceComparisonTests.swift
+++ b/Tests/CacheAdvanceTests/FlushableCachePerformanceComparisonTests.swift
@@ -25,7 +25,7 @@ final class FlushableCachePerformanceComparisonTests: XCTestCase {
         super.setUp()
 
         // Delete the existing cache.
-        FileManager.default.createFile(atPath: testFileLocation.path, contents: nil, attributes: nil)
+        XCTAssertTrue(FileManager.default.createFile(atPath: testFileLocation.path, contents: nil, attributes: nil))
     }
 
     // MARK: Behavior Tests

--- a/Tests/CacheAdvanceTests/SQLitePerformanceComparisonTests.swift
+++ b/Tests/CacheAdvanceTests/SQLitePerformanceComparisonTests.swift
@@ -15,6 +15,7 @@
 //  limitations under the License.
 //
 
+#if !os(Linux)
 import SQLite3
 import XCTest
 
@@ -318,3 +319,4 @@ class SQLiteCache<T: Codable> {
     }
 
 }
+#endif


### PR DESCRIPTION
This change required excluding `@objc` declarations from the build on Linux, and no longer using `NS*` function calls